### PR TITLE
fix(ci): bump Playwright webServer timeout and use bun

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,8 +2,9 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
 	webServer: {
-		command: 'npm run build && npm run preview',
-		port: 4173
+		command: 'bun run build && bun run preview',
+		port: 4173,
+		timeout: 180_000
 	},
 	testDir: 'e2e',
 	outputDir: 'playwright-report'


### PR DESCRIPTION
## Summary

The default 60s `webServer.timeout` in `playwright.config.ts` has been causing recurring CI failures during the SvelteKit build phase — the full `build && preview` cycle exceeds 60s in CI, so Playwright bails before tests even start. Recent failed runs include the npm-updates PRs from May 11 and May 19, the SEO audit work on May 7, and others.

This PR:

- Bumps `webServer.timeout` to 180s to cover a cold CI build.
- Switches the build/preview command from `npm` to `bun` for consistency with the rest of the project (CI installs with bun, CLAUDE.md documents `bun run build`, the workflow already uses `bunx playwright test`).

## Test plan

- [ ] CI Playwright job passes