### PR TITLE
Persist contact submissions to Postgres + Telegram notify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ DATABASE_URL=postgres://bootpack:bootpack@localhost:5432/bootpack
 # (e.g. https://api.telegram.org/bot<token>/getUpdates)
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
+
+# Cloudflare Turnstile (https://dash.cloudflare.com/?to=/:account/turnstile)
+PUBLIC_TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
 PUBLIC_ENABLE_POSTHOG=false
 PUBLIC_TEST_CONTACT_FORM=true
+
+# Local dev Postgres (matches docker-compose.yml)
+DATABASE_URL=postgres://bootpack:bootpack@localhost:5432/bootpack
+
+# Create a bot via @BotFather, then message the bot and look up your chat id
+# (e.g. https://api.telegram.org/bot<token>/getUpdates)
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           echo "PUBLIC_TEST_CONTACT_FORM=true" >> $GITHUB_ENV
           echo "PUBLIC_POSTHOG_ENABLED=false" >> $GITHUB_ENV
+          echo "PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA" >> $GITHUB_ENV
       - name: Run Playwright tests
         run: bunx playwright test
       - uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,12 @@ bun run db:studio     # Open Drizzle Studio
 - `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID`: Credentials for the Telegram
   notification fired on each contact submission (optional — missing creds
   are logged and skipped, the DB write still happens)
+- `PUBLIC_TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY`: Cloudflare Turnstile
+  credentials used by the contact form. Site key is rendered into the
+  widget on the client; secret key is used by `/api/contact` to verify
+  the submitted token via Cloudflare's siteverify endpoint. Missing
+  `TURNSTILE_SECRET_KEY` logs a warning and skips verification (intended
+  for local dev only).
 
 ### Contact form
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,16 @@ bun run out           # Check for outdated packages
 bun run up            # Update all dependencies
 ```
 
+### Database (local dev)
+
+```bash
+bun run db:up         # Start local Postgres in Docker
+bun run db:down       # Stop local Postgres
+bun run db:generate   # Generate SQL migrations from Drizzle schema changes
+bun run db:migrate    # Apply pending migrations to DATABASE_URL
+bun run db:studio     # Open Drizzle Studio
+```
+
 ## Architecture
 
 ### Framework Setup
@@ -100,7 +110,19 @@ bun run up            # Update all dependencies
 ### Environment Variables
 
 - `PUBLIC_POSTHOG_ENABLED`: Toggle PostHog analytics (default: enabled)
-- `PUBLIC_TEST_CONTACT_FORM`: Used for contact form testing
+- `PUBLIC_TEST_CONTACT_FORM`: Short-circuits the contact form so it shows the
+  success state without hitting `/api/contact` (used by e2e tests)
+- `DATABASE_URL`: Postgres connection string for the contact form endpoint
+- `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID`: Credentials for the Telegram
+  notification fired on each contact submission (optional — missing creds
+  are logged and skipped, the DB write still happens)
+
+### Contact form
+
+Submissions POST JSON to `src/routes/api/contact/+server.ts`, which validates,
+inserts into the `contact_submissions` table via Drizzle, and sends a Telegram
+notification. The Drizzle schema lives in `src/lib/server/db/schema.ts`;
+generated SQL migrations land in `drizzle/`.
 
 ### Image Handling
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,8 @@
         "@fontsource-variable/figtree": "^5.2.10",
         "@tailwindcss/vite": "^4.3.0",
         "clsx": "^2.1.1",
+        "drizzle-orm": "^0.45.2",
+        "postgres": "^3.4.9",
         "posthog-js": "^1.374.2",
         "svelte-adapter-bun": "^1.0.1",
       },
@@ -17,6 +19,7 @@
         "@sveltejs/kit": "^2.60.1",
         "@tailwindcss/typography": "^0.5.19",
         "@types/node": "^25.9.0",
+        "drizzle-kit": "^0.31.10",
         "eslint-plugin-svelte": "^3.17.1",
         "lefthook": "^2.1.6",
         "svelte": "^5.55.8",
@@ -31,11 +34,17 @@
     },
   },
   "packages": {
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -495,6 +504,8 @@
 
     "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
@@ -528,6 +539,10 @@
     "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
     "dompurify": ["dompurify@3.3.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ=="],
+
+    "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q=="],
 
@@ -580,6 +595,8 @@
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -743,6 +760,8 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
+
     "posthog-js": ["posthog-js@1.374.2", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.29.5", "@posthog/types": "1.374.2", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-6z1xGlVocd3NmSZlJNFfpedLIHLcejuuQPxvrpHDvtyVI9tN1NPqbM7T7coXw2It6gdZ/nAgDuZkNxfIut+Spw=="],
 
     "preact": ["preact@10.28.3", "", {}, "sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA=="],
@@ -756,6 +775,8 @@
     "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
 
@@ -775,7 +796,11 @@
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
@@ -810,6 +835,8 @@
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.22.3", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -848,6 +875,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
@@ -899,8 +928,106 @@
 
     "svelte-eslint-parser/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
+    "tsx/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
+
     "vite/postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: bootpack-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: bootpack
+      POSTGRES_PASSWORD: bootpack
+      POSTGRES_DB: bootpack
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U bootpack -d bootpack']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  postgres_data:

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'drizzle-kit';
+
+if (!process.env.DATABASE_URL) {
+	throw new Error('DATABASE_URL is not set');
+}
+
+export default defineConfig({
+	schema: './src/lib/server/db/schema.ts',
+	out: './drizzle',
+	dialect: 'postgresql',
+	dbCredentials: {
+		url: process.env.DATABASE_URL
+	}
+});

--- a/drizzle/0000_cooing_talos.sql
+++ b/drizzle/0000_cooing_talos.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "contact_submissions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"email" text NOT NULL,
+	"company" text,
+	"phone" text,
+	"message" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,81 @@
+{
+	"id": "3f8dda7e-3510-42d9-b79f-df55e1cecef5",
+	"prevId": "00000000-0000-0000-0000-000000000000",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.contact_submissions": {
+			"name": "contact_submissions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"company": {
+					"name": "company",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1779553847005,
+			"tag": "0000_cooing_talos",
+			"breakpoints": true
+		}
+	]
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,5 +3,5 @@ pre-commit:
   jobs:
     - name: format
       glob: '*.{js,jsx,ts,tsx,svelte,css,html,json,md,yaml,yml}'
-      run: bunx vp fmt --write {staged_files}
+      run: bunx vp fmt --write --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
-		"start": "bun ./server.js",
+		"start": "bun run db:migrate && bun ./server.js",
 		"package": "svelte-kit package",
 		"preview": "vite preview",
 		"check": "svelte-check --tsconfig ./tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,12 @@
 		"out": "bun outdated",
 		"up": "bun update",
 		"test:e2e": "playwright test",
-		"test": "bun run test:e2e"
+		"test": "bun run test:e2e",
+		"db:up": "docker compose up -d postgres",
+		"db:down": "docker compose down",
+		"db:generate": "drizzle-kit generate",
+		"db:migrate": "drizzle-kit migrate",
+		"db:studio": "drizzle-kit studio"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",
@@ -23,6 +28,7 @@
 		"@sveltejs/kit": "^2.60.1",
 		"@tailwindcss/typography": "^0.5.19",
 		"@types/node": "^25.9.0",
+		"drizzle-kit": "^0.31.10",
 		"eslint-plugin-svelte": "^3.17.1",
 		"lefthook": "^2.1.6",
 		"svelte": "^5.55.8",
@@ -39,6 +45,8 @@
 		"@fontsource-variable/figtree": "^5.2.10",
 		"@tailwindcss/vite": "^4.3.0",
 		"clsx": "^2.1.1",
+		"drizzle-orm": "^0.45.2",
+		"postgres": "^3.4.9",
 		"posthog-js": "^1.374.2",
 		"svelte-adapter-bun": "^1.0.1"
 	},

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"test:e2e": "playwright test",
 		"test": "bun run test:e2e",
 		"db:up": "docker compose up -d postgres",
-		"db:down": "docker compose down",
+		"db:down": "docker compose down postgres",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:studio": "drizzle-kit studio"

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -9,3 +9,11 @@ declare namespace App {
 	// interface Session {}
 	// interface Stuff {}
 }
+
+interface Window {
+	turnstile?: {
+		reset: (widgetId?: string) => void;
+		render: (container: string | HTMLElement, options: Record<string, unknown>) => string;
+		remove: (widgetId: string) => void;
+	};
+}

--- a/src/components/contact-form.svelte
+++ b/src/components/contact-form.svelte
@@ -3,7 +3,10 @@
 	import clsx from 'clsx';
 
 	let submitted = $state(false);
-	let isSubmitting = false;
+	let isSubmitting = $state(false);
+	let errors: Record<string, string> = {};
+	let errorMessage = $state('');
+	let touched: Record<string, boolean> = {};
 
 	const handleSubmit = async (event: SubmitEvent) => {
 		event.preventDefault();
@@ -14,40 +17,41 @@
 		}
 
 		const formData = new FormData(event.target as HTMLFormElement);
+		const payload = {
+			firstName: formData.get('firstName'),
+			lastName: formData.get('lastName'),
+			email: formData.get('email'),
+			company: formData.get('company'),
+			phone: formData.get('phone'),
+			message: formData.get('message')
+		};
 
-		fetch('https://formspree.io/f/xgerlrdz', {
-			method: 'POST',
-			body: formData,
-			headers: {
-				Accept: 'application/json'
-			}
-		})
-			.then((response) => {
-				if (response.ok) {
-					submitted = true;
-					// form.reset();
-				} else {
-					response.json().then((data) => {
-						console.error(data);
-						if (Object.hasOwn(data, 'errors')) {
-							errorMessage = data['errors']
-								.map((error: Record<'message', string>) => error['message'])
-								.join(', ');
-						} else {
-							errorMessage = 'Oops! There was a problem submitting your form';
-						}
-					});
-				}
-			})
-			.catch((error) => {
-				console.error(error);
-				errorMessage = 'Oops! There was a problem submitting your form';
+		isSubmitting = true;
+		errorMessage = '';
+
+		try {
+			const response = await fetch('/api/contact', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json'
+				},
+				body: JSON.stringify(payload)
 			});
-	};
 
-	let errors: Record<string, string> = {};
-	let errorMessage = $state('');
-	let touched: Record<string, boolean> = {};
+			if (response.ok) {
+				submitted = true;
+			} else {
+				const data = await response.json().catch(() => ({}));
+				errorMessage = data?.error ?? 'Oops! There was a problem submitting your form';
+			}
+		} catch (error) {
+			console.error(error);
+			errorMessage = 'Oops! There was a problem submitting your form';
+		} finally {
+			isSubmitting = false;
+		}
+	};
 </script>
 
 <form class={submitted ? `hidden` : `visible`} name="contact" onsubmit={handleSubmit}>

--- a/src/components/contact-form.svelte
+++ b/src/components/contact-form.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { PUBLIC_TEST_CONTACT_FORM } from '$env/static/public';
+	import { PUBLIC_TEST_CONTACT_FORM, PUBLIC_TURNSTILE_SITE_KEY } from '$env/static/public';
 	import clsx from 'clsx';
 
 	let submitted = $state(false);
@@ -16,14 +16,23 @@
 			return;
 		}
 
-		const formData = new FormData(event.target as HTMLFormElement);
+		const form = event.target as HTMLFormElement;
+		const formData = new FormData(form);
+		const turnstileToken = formData.get('cf-turnstile-response');
+
+		if (!turnstileToken) {
+			errorMessage = 'Please complete the captcha before submitting';
+			return;
+		}
+
 		const payload = {
 			firstName: formData.get('firstName'),
 			lastName: formData.get('lastName'),
 			email: formData.get('email'),
 			company: formData.get('company'),
 			phone: formData.get('phone'),
-			message: formData.get('message')
+			message: formData.get('message'),
+			turnstileToken
 		};
 
 		isSubmitting = true;
@@ -44,15 +53,25 @@
 			} else {
 				const data = await response.json().catch(() => ({}));
 				errorMessage = data?.error ?? 'Oops! There was a problem submitting your form';
+				if (typeof window !== 'undefined' && window.turnstile) {
+					window.turnstile.reset();
+				}
 			}
 		} catch (error) {
 			console.error(error);
 			errorMessage = 'Oops! There was a problem submitting your form';
+			if (typeof window !== 'undefined' && window.turnstile) {
+				window.turnstile.reset();
+			}
 		} finally {
 			isSubmitting = false;
 		}
 	};
 </script>
+
+<svelte:head>
+	<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+</svelte:head>
 
 <form class={submitted ? `hidden` : `visible`} name="contact" onsubmit={handleSubmit}>
 	<div class="flex flex-wrap -mx-3 mt-8 mb-6">
@@ -166,6 +185,9 @@
 				{/if}
 			</p>
 		</div>
+	</div>
+	<div class="mb-6">
+		<div class="cf-turnstile" data-sitekey={PUBLIC_TURNSTILE_SITE_KEY}></div>
 	</div>
 	{#if errorMessage}
 		<p class="px-2 pt-1 text-xs italic text-red-500">

--- a/src/components/contact-form.svelte
+++ b/src/components/contact-form.svelte
@@ -186,8 +186,12 @@
 			</p>
 		</div>
 	</div>
-	<div class="mb-6">
-		<div class="cf-turnstile" data-sitekey={PUBLIC_TURNSTILE_SITE_KEY}></div>
+	<div class={clsx('mb-6 flex justify-start', 'xl:justify-end')}>
+		<div
+			class="cf-turnstile"
+			data-sitekey={PUBLIC_TURNSTILE_SITE_KEY}
+			data-theme="light"
+		></div>
 	</div>
 	{#if errorMessage}
 		<p class="px-2 pt-1 text-xs italic text-red-500">

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,0 +1,18 @@
+import { env } from '$env/dynamic/private';
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as schema from './schema';
+
+let cached: PostgresJsDatabase<typeof schema> | undefined;
+
+export function getDb(): PostgresJsDatabase<typeof schema> {
+	if (cached) return cached;
+
+	if (!env.DATABASE_URL) {
+		throw new Error('DATABASE_URL is not set');
+	}
+
+	const client = postgres(env.DATABASE_URL, { max: 1 });
+	cached = drizzle(client, { schema });
+	return cached;
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,0 +1,15 @@
+import { pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const contactSubmissions = pgTable('contact_submissions', {
+	id: serial('id').primaryKey(),
+	firstName: text('first_name').notNull(),
+	lastName: text('last_name').notNull(),
+	email: text('email').notNull(),
+	company: text('company'),
+	phone: text('phone'),
+	message: text('message').notNull(),
+	createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+});
+
+export type ContactSubmission = typeof contactSubmissions.$inferSelect;
+export type NewContactSubmission = typeof contactSubmissions.$inferInsert;

--- a/src/lib/server/telegram.ts
+++ b/src/lib/server/telegram.ts
@@ -1,6 +1,7 @@
 import { env } from '$env/dynamic/private';
 
 const TELEGRAM_API = 'https://api.telegram.org';
+const TELEGRAM_TIMEOUT_MS = 5000;
 
 export async function sendTelegramMessage(text: string): Promise<void> {
 	const token = env.TELEGRAM_BOT_TOKEN;
@@ -11,16 +12,25 @@ export async function sendTelegramMessage(text: string): Promise<void> {
 		return;
 	}
 
-	const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			chat_id: chatId,
-			text,
-			parse_mode: 'HTML',
-			disable_web_page_preview: true
-		})
-	});
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), TELEGRAM_TIMEOUT_MS);
+
+	let res: Response;
+	try {
+		res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				chat_id: chatId,
+				text,
+				parse_mode: 'HTML',
+				disable_web_page_preview: true
+			}),
+			signal: controller.signal
+		});
+	} finally {
+		clearTimeout(timeout);
+	}
 
 	if (!res.ok) {
 		const body = await res.text();

--- a/src/lib/server/telegram.ts
+++ b/src/lib/server/telegram.ts
@@ -1,0 +1,60 @@
+import { env } from '$env/dynamic/private';
+
+const TELEGRAM_API = 'https://api.telegram.org';
+
+export async function sendTelegramMessage(text: string): Promise<void> {
+	const token = env.TELEGRAM_BOT_TOKEN;
+	const chatId = env.TELEGRAM_CHAT_ID;
+
+	if (!token || !chatId) {
+		console.warn('Telegram credentials missing; skipping notification');
+		return;
+	}
+
+	const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			chat_id: chatId,
+			text,
+			parse_mode: 'HTML',
+			disable_web_page_preview: true
+		})
+	});
+
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(`Telegram sendMessage failed: ${res.status} ${body}`);
+	}
+}
+
+function escapeHtml(value: string): string {
+	return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function formatContactMessage(submission: {
+	firstName: string;
+	lastName: string;
+	email: string;
+	company?: string | null;
+	phone?: string | null;
+	message: string;
+}): string {
+	const lines = [
+		'<b>New contact form submission</b>',
+		'',
+		`<b>Name:</b> ${escapeHtml(submission.firstName)} ${escapeHtml(submission.lastName)}`,
+		`<b>Email:</b> ${escapeHtml(submission.email)}`
+	];
+
+	if (submission.company) {
+		lines.push(`<b>Company:</b> ${escapeHtml(submission.company)}`);
+	}
+	if (submission.phone) {
+		lines.push(`<b>Phone:</b> ${escapeHtml(submission.phone)}`);
+	}
+
+	lines.push('', '<b>Message:</b>', escapeHtml(submission.message));
+
+	return lines.join('\n');
+}

--- a/src/lib/server/turnstile.ts
+++ b/src/lib/server/turnstile.ts
@@ -1,0 +1,48 @@
+import { env } from '$env/dynamic/private';
+
+const VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+const VERIFY_TIMEOUT_MS = 5000;
+
+type SiteverifyResponse = {
+	success: boolean;
+	'error-codes'?: string[];
+};
+
+export async function verifyTurnstileToken(token: string, remoteIp?: string): Promise<boolean> {
+	const secret = env.TURNSTILE_SECRET_KEY;
+	if (!secret) {
+		console.warn('TURNSTILE_SECRET_KEY missing; skipping captcha verification');
+		return true;
+	}
+
+	const body = new URLSearchParams({ secret, response: token });
+	if (remoteIp) body.set('remoteip', remoteIp);
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+
+	try {
+		const res = await fetch(VERIFY_URL, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body,
+			signal: controller.signal
+		});
+
+		if (!res.ok) return false;
+
+		const data = (await res.json()) as SiteverifyResponse;
+		if (!data.success) {
+			console.warn('Turnstile verification failed:', data['error-codes']);
+		}
+		return data.success;
+	} catch (err) {
+		console.error(
+			'Turnstile verification error:',
+			err instanceof Error ? err.message : 'unknown error'
+		);
+		return false;
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/src/routes/api/contact/+server.ts
+++ b/src/routes/api/contact/+server.ts
@@ -2,6 +2,7 @@ import { json } from '@sveltejs/kit';
 import { getDb } from '$lib/server/db';
 import { contactSubmissions } from '$lib/server/db/schema';
 import { formatContactMessage, sendTelegramMessage } from '$lib/server/telegram';
+import { verifyTurnstileToken } from '$lib/server/turnstile';
 import type { RequestHandler } from './$types';
 
 export const prerender = false;
@@ -16,6 +17,7 @@ type Payload = {
 	company?: unknown;
 	phone?: unknown;
 	message?: unknown;
+	turnstileToken?: unknown;
 };
 
 function asTrimmedString(value: unknown, max = MAX_LEN): string | null {
@@ -29,7 +31,7 @@ function errorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : 'unknown error';
 }
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	let payload: Payload;
 	try {
 		const parsed: unknown = await request.json();
@@ -47,6 +49,7 @@ export const POST: RequestHandler = async ({ request }) => {
 	const message = asTrimmedString(payload.message);
 	const company = asTrimmedString(payload.company, 200);
 	const phone = asTrimmedString(payload.phone, 50);
+	const turnstileToken = asTrimmedString(payload.turnstileToken, 2048);
 
 	if (!firstName || !lastName || !email || !message) {
 		return json({ error: 'Missing required fields' }, { status: 400 });
@@ -54,6 +57,15 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	if (!EMAIL_RE.test(email)) {
 		return json({ error: 'Invalid email' }, { status: 400 });
+	}
+
+	if (!turnstileToken) {
+		return json({ error: 'Captcha token missing' }, { status: 400 });
+	}
+
+	const captchaOk = await verifyTurnstileToken(turnstileToken, getClientAddress());
+	if (!captchaOk) {
+		return json({ error: 'Captcha verification failed' }, { status: 400 });
 	}
 
 	const submission = { firstName, lastName, email, company, phone, message };

--- a/src/routes/api/contact/+server.ts
+++ b/src/routes/api/contact/+server.ts
@@ -1,0 +1,66 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { getDb } from '$lib/server/db';
+import { contactSubmissions } from '$lib/server/db/schema';
+import { formatContactMessage, sendTelegramMessage } from '$lib/server/telegram';
+
+export const prerender = false;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_LEN = 5000;
+
+type Payload = {
+	firstName?: unknown;
+	lastName?: unknown;
+	email?: unknown;
+	company?: unknown;
+	phone?: unknown;
+	message?: unknown;
+};
+
+function asTrimmedString(value: unknown, max = MAX_LEN): string | null {
+	if (typeof value !== 'string') return null;
+	const trimmed = value.trim();
+	if (!trimmed || trimmed.length > max) return null;
+	return trimmed;
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	let payload: Payload;
+	try {
+		payload = (await request.json()) as Payload;
+	} catch {
+		return json({ error: 'Invalid JSON' }, { status: 400 });
+	}
+
+	const firstName = asTrimmedString(payload.firstName, 200);
+	const lastName = asTrimmedString(payload.lastName, 200);
+	const email = asTrimmedString(payload.email, 320);
+	const message = asTrimmedString(payload.message);
+	const company = asTrimmedString(payload.company, 200);
+	const phone = asTrimmedString(payload.phone, 50);
+
+	if (!firstName || !lastName || !email || !message) {
+		return json({ error: 'Missing required fields' }, { status: 400 });
+	}
+
+	if (!EMAIL_RE.test(email)) {
+		return json({ error: 'Invalid email' }, { status: 400 });
+	}
+
+	const submission = { firstName, lastName, email, company, phone, message };
+
+	try {
+		await getDb().insert(contactSubmissions).values(submission);
+	} catch (err) {
+		console.error('Failed to insert contact submission', err);
+		return json({ error: 'Could not save submission' }, { status: 500 });
+	}
+
+	try {
+		await sendTelegramMessage(formatContactMessage(submission));
+	} catch (err) {
+		console.error('Failed to send Telegram notification', err);
+	}
+
+	return json({ ok: true });
+};

--- a/src/routes/api/contact/+server.ts
+++ b/src/routes/api/contact/+server.ts
@@ -1,7 +1,8 @@
-import { json, type RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import { getDb } from '$lib/server/db';
 import { contactSubmissions } from '$lib/server/db/schema';
 import { formatContactMessage, sendTelegramMessage } from '$lib/server/telegram';
+import type { RequestHandler } from './$types';
 
 export const prerender = false;
 
@@ -24,10 +25,18 @@ function asTrimmedString(value: unknown, max = MAX_LEN): string | null {
 	return trimmed;
 }
 
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : 'unknown error';
+}
+
 export const POST: RequestHandler = async ({ request }) => {
 	let payload: Payload;
 	try {
-		payload = (await request.json()) as Payload;
+		const parsed: unknown = await request.json();
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			return json({ error: 'Invalid payload' }, { status: 400 });
+		}
+		payload = parsed as Payload;
 	} catch {
 		return json({ error: 'Invalid JSON' }, { status: 400 });
 	}
@@ -52,14 +61,14 @@ export const POST: RequestHandler = async ({ request }) => {
 	try {
 		await getDb().insert(contactSubmissions).values(submission);
 	} catch (err) {
-		console.error('Failed to insert contact submission', err);
+		console.error('Failed to insert contact submission:', errorMessage(err));
 		return json({ error: 'Could not save submission' }, { status: 500 });
 	}
 
 	try {
 		await sendTelegramMessage(formatContactMessage(submission));
 	} catch (err) {
-		console.error('Failed to send Telegram notification', err);
+		console.error('Failed to send Telegram notification:', errorMessage(err));
 	}
 
 	return json({ ok: true });


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with Postgres 16 for local dev
- Add Drizzle ORM (schema + lazy postgres-js client + initial migration) and `db:*` scripts
- Add `/api/contact` endpoint that validates JSON, inserts into `contact_submissions`, and fires a Telegram `sendMessage`
- Switch `ContactForm` from Formspree to the new endpoint
- Document new env vars (`DATABASE_URL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`) and dev workflow in `CLAUDE.md` / `.env.example`

## Notes
- Telegram creds are optional — missing values log a warning and skip the notification; the DB write still succeeds
- `PUBLIC_TEST_CONTACT_FORM=true` still short-circuits the form for e2e tests
- Production DB hosting is deferred; the code reads `DATABASE_URL` so it'll work against whatever you point it at (Neon/Supabase/self-hosted). Run `bun run db:migrate` against the prod DB once chosen
- Lint baseline on master has 22 pre-existing eslint `no-undef` errors for Svelte 5 runes (`$state`, `$props`, `$derived` not configured as globals). This PR adds 1 more of the same kind in `contact-form.svelte` — a config gap, not new code quality issues

## Test plan
- [ ] `bun run db:up` and `bun run db:migrate` apply cleanly
- [ ] `bun run dev`, submit the contact form, confirm a row lands in `contact_submissions`
- [ ] Set `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` and confirm the bot DMs the chat on submission
- [ ] With Telegram unset, submit and confirm the row still saves (warning in logs)
- [ ] Invalid payloads return 400 with `{error}` JSON; valid payloads return `{ok:true}`
- [ ] `bun run build` succeeds (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contact form now submits to a server API, stores submissions in the database, and can send optional Telegram notifications.

* **Documentation**
  * Expanded local development guide with DB setup, migration workflow, and contact form behavior and configuration.

* **Chores**
  * Added local Postgres compose config, example env vars, DB migrations/tools, and scripts to manage the local database and run migrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michaelbonner/bootpack-digital/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->