### PR TITLE
Add "Bootpack for Good" free-website landing page and application form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,9 @@ bun run db:studio     # Open Drizzle Studio
 
 - Standard SvelteKit file-based routing in `src/routes/`
 - Main pages: Home (`/`), Work (`/work`), About (`/about`), Open-source (`/open-source`), Contact (`/contact`)
+- Bootpack for Good (`/bootpack-for-good`): landing page + application form for the
+  quarterly free-website giveaway to Salt Lake–area nonprofits and community orgs
+  (linked from the footer)
 - Policies section with Termageddon integration for legal pages
 - All pages are prerendered at build time
 
@@ -110,8 +113,9 @@ bun run db:studio     # Open Drizzle Studio
 ### Environment Variables
 
 - `PUBLIC_POSTHOG_ENABLED`: Toggle PostHog analytics (default: enabled)
-- `PUBLIC_TEST_CONTACT_FORM`: Short-circuits the contact form so it shows the
-  success state without hitting `/api/contact` (used by e2e tests)
+- `PUBLIC_TEST_CONTACT_FORM`: Short-circuits the contact form and the Bootpack for
+  Good application form so they show the success state without hitting their API
+  routes (used by e2e tests)
 - `DATABASE_URL`: Postgres connection string for the contact form endpoint
 - `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID`: Credentials for the Telegram
   notification fired on each contact submission (optional — missing creds
@@ -129,6 +133,13 @@ Submissions POST JSON to `src/routes/api/contact/+server.ts`, which validates,
 inserts into the `contact_submissions` table via Drizzle, and sends a Telegram
 notification. The Drizzle schema lives in `src/lib/server/db/schema.ts`;
 generated SQL migrations land in `drizzle/`.
+
+### Bootpack for Good application form
+
+The `/bootpack-for-good` page (`free-website-form.svelte`) POSTs JSON to
+`src/routes/api/free-website/+server.ts`, which mirrors the contact endpoint:
+validate, verify Turnstile, insert into the `free_website_applications` table
+via Drizzle, and send a Telegram notification (`formatFreeWebsiteApplication`).
 
 ### Image Handling
 

--- a/drizzle/0001_naive_aaron_stack.sql
+++ b/drizzle/0001_naive_aaron_stack.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "free_website_applications" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"email" text NOT NULL,
+	"phone" text,
+	"organization_name" text NOT NULL,
+	"organization_type" text,
+	"website" text,
+	"city" text NOT NULL,
+	"mission" text NOT NULL,
+	"goals" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,167 @@
+{
+	"id": "e53a0932-a989-4c30-9721-be224d81ee5c",
+	"prevId": "3f8dda7e-3510-42d9-b79f-df55e1cecef5",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.contact_submissions": {
+			"name": "contact_submissions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"company": {
+					"name": "company",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.free_website_applications": {
+			"name": "free_website_applications",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"phone": {
+					"name": "phone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"organization_name": {
+					"name": "organization_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_type": {
+					"name": "organization_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"website": {
+					"name": "website",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"city": {
+					"name": "city",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"mission": {
+					"name": "mission",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"goals": {
+					"name": "goals",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
 			"when": 1779553847005,
 			"tag": "0000_cooing_talos",
 			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1779565598506,
+			"tag": "0001_naive_aaron_stack",
+			"breakpoints": true
 		}
 	]
 }

--- a/e2e/around-the-world.test.ts
+++ b/e2e/around-the-world.test.ts
@@ -16,6 +16,9 @@ test('can load all pages', async ({ page }) => {
 	await page.goto('/contact');
 	await expect(page.locator('h1')).toBeVisible();
 
+	await page.goto('/bootpack-for-good');
+	await expect(page.locator('h1')).toBeVisible();
+
 	await page.goto('/policies');
 	await expect(page.locator('h1')).toBeVisible();
 

--- a/e2e/test-free-website-form.test.ts
+++ b/e2e/test-free-website-form.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test('free website application form', async ({ page }) => {
+	await page.goto('/bootpack-for-good');
+	await page.getByRole('textbox', { name: 'First Name*' }).fill('Test');
+	await page.getByRole('textbox', { name: 'Last Name*' }).fill('Test');
+	await page.getByRole('textbox', { name: 'Email*' }).fill('test@test.test');
+	await page.getByRole('textbox', { name: 'Phone Number' }).fill('8012223333');
+	await page.getByRole('textbox', { name: 'Organization Name*' }).fill('Test Org');
+	await page.getByLabel('Organization Type').selectOption('Nonprofit (501c3)');
+	await page.getByRole('textbox', { name: 'City / Area*' }).fill('Salt Lake City');
+	await page
+		.getByRole('textbox', { name: 'Tell us about your organization and the good you do*' })
+		.fill('We help the local community.');
+	await page
+		.getByRole('textbox', { name: 'What would a website help you accomplish?*' })
+		.fill('Reach more people and share our programs.');
+	await page.getByRole('checkbox').check();
+	await page.getByRole('button', { name: 'Apply for a free website' }).click();
+	await expect(page.getByText('Application received!')).toBeVisible();
+});

--- a/e2e/test-free-website-form.test.ts
+++ b/e2e/test-free-website-form.test.ts
@@ -2,18 +2,18 @@ import { test, expect } from '@playwright/test';
 
 test('free website application form', async ({ page }) => {
 	await page.goto('/bootpack-for-good');
-	await page.getByRole('textbox', { name: 'First Name*' }).fill('Test');
-	await page.getByRole('textbox', { name: 'Last Name*' }).fill('Test');
-	await page.getByRole('textbox', { name: 'Email*' }).fill('test@test.test');
+	await page.getByRole('textbox', { name: 'First Name' }).fill('Test');
+	await page.getByRole('textbox', { name: 'Last Name' }).fill('Test');
+	await page.getByRole('textbox', { name: 'Email' }).fill('test@test.test');
 	await page.getByRole('textbox', { name: 'Phone Number' }).fill('8012223333');
-	await page.getByRole('textbox', { name: 'Organization Name*' }).fill('Test Org');
+	await page.getByRole('textbox', { name: 'Organization Name' }).fill('Test Org');
 	await page.getByLabel('Organization Type').selectOption('Nonprofit (501c3)');
-	await page.getByRole('textbox', { name: 'City / Area*' }).fill('Salt Lake City');
+	await page.getByRole('textbox', { name: 'City / Area' }).fill('Salt Lake City');
 	await page
-		.getByRole('textbox', { name: 'Tell us about your organization and the good you do*' })
+		.getByRole('textbox', { name: 'Tell us about your organization and the good you do' })
 		.fill('We help the local community.');
 	await page
-		.getByRole('textbox', { name: 'What would a website help you accomplish?*' })
+		.getByRole('textbox', { name: 'What would a website help you accomplish?' })
 		.fill('Reach more people and share our programs.');
 	await page.getByRole('checkbox').check();
 	await page.getByRole('button', { name: 'Apply for a free website' }).click();

--- a/e2e/test-free-website-form.test.ts
+++ b/e2e/test-free-website-form.test.ts
@@ -15,7 +15,6 @@ test('free website application form', async ({ page }) => {
 	await page
 		.getByRole('textbox', { name: 'What would a website help you accomplish?' })
 		.fill('Reach more people and share our programs.');
-	await page.getByRole('checkbox').check();
 	await page.getByRole('button', { name: 'Apply for a free website' }).click();
 	await expect(page.getByText('Application received!')).toBeVisible();
 });

--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -24,7 +24,11 @@
 		}
 	});
 
-	const links = [...navLinks, { label: 'Policies', url: '/policies' as RouteId }];
+	const links = [
+		...navLinks,
+		{ label: 'Bootpack for Good', url: '/bootpack-for-good' as RouteId },
+		{ label: 'Policies', url: '/policies' as RouteId }
+	];
 </script>
 
 <footer

--- a/src/components/free-website-form.svelte
+++ b/src/components/free-website-form.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+	import { PUBLIC_TEST_CONTACT_FORM, PUBLIC_TURNSTILE_SITE_KEY } from '$env/static/public';
+	import clsx from 'clsx';
+
+	let submitted = $state(false);
+	let isSubmitting = $state(false);
+	let errorMessage = $state('');
+
+	const inputClass =
+		'block py-3 px-4 w-full leading-tight text-gray-700 bg-gray-100 rounded-sm border border-gray-100 appearance-none focus:bg-white focus:border-gray-500 focus:outline-hidden';
+	const labelClass = 'block mb-2 text-xs font-bold tracking-wide text-gray-700';
+
+	const handleSubmit = async (event: SubmitEvent) => {
+		event.preventDefault();
+
+		if (PUBLIC_TEST_CONTACT_FORM === 'true') {
+			submitted = true;
+			return;
+		}
+
+		const form = event.target as HTMLFormElement;
+		const formData = new FormData(form);
+		const turnstileToken = formData.get('cf-turnstile-response');
+
+		if (!turnstileToken) {
+			errorMessage = 'Please complete the captcha before submitting';
+			return;
+		}
+
+		const payload = {
+			firstName: formData.get('firstName'),
+			lastName: formData.get('lastName'),
+			email: formData.get('email'),
+			phone: formData.get('phone'),
+			organizationName: formData.get('organizationName'),
+			organizationType: formData.get('organizationType'),
+			website: formData.get('website'),
+			city: formData.get('city'),
+			mission: formData.get('mission'),
+			goals: formData.get('goals'),
+			turnstileToken
+		};
+
+		isSubmitting = true;
+		errorMessage = '';
+
+		try {
+			const response = await fetch('/api/free-website', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json'
+				},
+				body: JSON.stringify(payload)
+			});
+
+			if (response.ok) {
+				submitted = true;
+			} else {
+				const data = await response.json().catch(() => ({}));
+				errorMessage = data?.error ?? 'Oops! There was a problem submitting your application';
+				if (typeof window !== 'undefined' && window.turnstile) {
+					window.turnstile.reset();
+				}
+			}
+		} catch (error) {
+			console.error(error);
+			errorMessage = 'Oops! There was a problem submitting your application';
+			if (typeof window !== 'undefined' && window.turnstile) {
+				window.turnstile.reset();
+			}
+		} finally {
+			isSubmitting = false;
+		}
+	};
+</script>
+
+<svelte:head>
+	<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+</svelte:head>
+
+<form class={submitted ? `hidden` : `visible`} name="free-website" onsubmit={handleSubmit}>
+	<div class="flex flex-wrap -mx-3 mb-6">
+		<div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
+			<label class={labelClass} for="firstName">First Name*</label>
+			<input
+				aria-required="true"
+				class={inputClass}
+				id="firstName"
+				name="firstName"
+				placeholder="Jane"
+				required
+				type="text"
+			/>
+		</div>
+		<div class="px-3 w-full md:w-1/2">
+			<label class={labelClass} for="lastName">Last Name*</label>
+			<input
+				aria-required="true"
+				class={inputClass}
+				id="lastName"
+				name="lastName"
+				placeholder="Doe"
+				required
+				type="text"
+			/>
+		</div>
+	</div>
+	<div class="flex flex-wrap -mx-3 mb-6">
+		<div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
+			<label class={labelClass} for="email">Email*</label>
+			<input
+				aria-required="true"
+				class={inputClass}
+				id="email"
+				name="email"
+				placeholder="jane@organization.org"
+				required
+				type="email"
+			/>
+		</div>
+		<div class="px-3 w-full md:w-1/2">
+			<label class={labelClass} for="phone">Phone Number</label>
+			<input class={inputClass} id="phone" name="phone" placeholder="801-111-2222" type="text" />
+		</div>
+	</div>
+	<div class="flex flex-wrap -mx-3 mb-6">
+		<div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
+			<label class={labelClass} for="organizationName">Organization Name*</label>
+			<input
+				aria-required="true"
+				class={inputClass}
+				id="organizationName"
+				name="organizationName"
+				placeholder="Wasatch Community Project"
+				required
+				type="text"
+			/>
+		</div>
+		<div class="px-3 w-full md:w-1/2">
+			<label class={labelClass} for="organizationType">Organization Type</label>
+			<select class={inputClass} id="organizationType" name="organizationType">
+				<option value="">Select one</option>
+				<option value="Nonprofit (501c3)">Nonprofit (501(c)(3))</option>
+				<option value="Community organization">Community organization</option>
+				<option value="Mutual aid / grassroots group">Mutual aid / grassroots group</option>
+				<option value="Faith-based organization">Faith-based organization</option>
+				<option value="School / education">School / education</option>
+				<option value="Other">Other</option>
+			</select>
+		</div>
+	</div>
+	<div class="flex flex-wrap -mx-3 mb-6">
+		<div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
+			<label class={labelClass} for="city">City / Area*</label>
+			<input
+				aria-required="true"
+				class={inputClass}
+				id="city"
+				name="city"
+				placeholder="Salt Lake City"
+				required
+				type="text"
+			/>
+		</div>
+		<div class="px-3 w-full md:w-1/2">
+			<label class={labelClass} for="website">Current Website (if any)</label>
+			<input
+				class={inputClass}
+				id="website"
+				name="website"
+				placeholder="https://example.org"
+				type="text"
+			/>
+		</div>
+	</div>
+	<div class="flex flex-wrap -mx-3 mb-6">
+		<div class="px-3 w-full">
+			<label class={labelClass} for="mission">Tell us about your organization and the good you do*</label>
+			<textarea
+				aria-required="true"
+				class={inputClass}
+				id="mission"
+				name="mission"
+				placeholder="What's your mission? Who do you serve, and what impact are you trying to make in the community?"
+				required
+				rows={6}
+			></textarea>
+		</div>
+	</div>
+	<div class="flex flex-wrap -mx-3 mb-6">
+		<div class="px-3 w-full">
+			<label class={labelClass} for="goals">What would a website help you accomplish?*</label>
+			<textarea
+				aria-required="true"
+				class={inputClass}
+				id="goals"
+				name="goals"
+				placeholder="What pages or content do you need (home, about, programs, contact)? What should visitors be able to do?"
+				required
+				rows={6}
+			></textarea>
+		</div>
+	</div>
+	<div class="flex items-start px-3 mb-6">
+		<input
+			class="mt-1 mr-3 w-4 h-4"
+			id="ownership"
+			name="ownership"
+			required
+			type="checkbox"
+		/>
+		<label class="text-sm text-gray-600" for="ownership">
+			I understand that we'll own the website's Git repository and control its deployment, so we can
+			maintain and update it ourselves later.*
+		</label>
+	</div>
+	<div class={clsx('mb-6 flex justify-start', 'xl:justify-end')}>
+		<div class="cf-turnstile" data-sitekey={PUBLIC_TURNSTILE_SITE_KEY} data-theme="light"></div>
+	</div>
+	{#if errorMessage}
+		<p class="px-2 pt-1 text-xs italic text-red-500">
+			{errorMessage}
+		</p>
+	{/if}
+	<div class={clsx('flex justify-start', 'xl:justify-end')}>
+		<button
+			class={clsx(
+				'py-3 px-5 w-full text-base font-medium leading-6 text-white bg-orange-700 rounded-md border border-transparent transition duration-150 ease-in-out',
+				'lg:w-auto',
+				'hover:bg-orange-600',
+				'focus:outline-hidden focus:shadow-outline'
+			)}
+			disabled={isSubmitting}
+			type="submit"
+		>
+			Apply for a free website
+		</button>
+	</div>
+</form>
+<div class={submitted ? `visible` : `hidden`}>
+	<h2 class="text-navy-600">Application received!</h2>
+	<p class="text-gray-600">
+		Thank you for telling us about your organization. We review applications every quarter and will
+		be in touch if you're selected. In the meantime, keep up the good work.
+	</p>
+</div>

--- a/src/components/free-website-form.svelte
+++ b/src/components/free-website-form.svelte
@@ -7,8 +7,8 @@
 	let errorMessage = $state('');
 
 	const inputClass =
-		'block py-3 px-4 w-full leading-tight text-gray-700 bg-gray-100 rounded-sm border border-gray-100 appearance-none focus:bg-white focus:border-gray-500 focus:outline-hidden';
-	const labelClass = 'block mb-2 text-xs font-bold tracking-wide text-gray-700';
+		'block py-3 px-4 w-full text-base text-gray-700 bg-gray-100 rounded-md border border-gray-200 appearance-none transition-colors focus:bg-white focus:outline-2 focus:-outline-offset-1 focus:outline-blue-500';
+	const labelClass = 'block mb-2 text-sm font-semibold tracking-wide text-gray-700';
 
 	const handleSubmit = async (event: SubmitEvent) => {
 		event.preventDefault();
@@ -79,10 +79,12 @@
 	<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 </svelte:head>
 
-<form class={submitted ? `hidden` : `visible`} name="free-website" onsubmit={handleSubmit}>
-	<div class="flex flex-wrap -mx-3 mb-6">
-		<div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
-			<label class={labelClass} for="firstName">First Name*</label>
+<form class={clsx(submitted && 'hidden')} name="free-website" onsubmit={handleSubmit}>
+	<div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+		<div>
+			<label class={labelClass} for="firstName">
+				First Name <span aria-hidden="true" class="text-orange-600">*</span>
+			</label>
 			<input
 				aria-required="true"
 				class={inputClass}
@@ -93,8 +95,10 @@
 				type="text"
 			/>
 		</div>
-		<div class="px-3 w-full md:w-1/2">
-			<label class={labelClass} for="lastName">Last Name*</label>
+		<div>
+			<label class={labelClass} for="lastName">
+				Last Name <span aria-hidden="true" class="text-orange-600">*</span>
+			</label>
 			<input
 				aria-required="true"
 				class={inputClass}
@@ -105,10 +109,10 @@
 				type="text"
 			/>
 		</div>
-	</div>
-	<div class="flex flex-wrap -mx-3 mb-6">
-		<div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
-			<label class={labelClass} for="email">Email*</label>
+		<div>
+			<label class={labelClass} for="email">
+				Email <span aria-hidden="true" class="text-orange-600">*</span>
+			</label>
 			<input
 				aria-required="true"
 				class={inputClass}
@@ -119,14 +123,14 @@
 				type="email"
 			/>
 		</div>
-		<div class="px-3 w-full md:w-1/2">
+		<div>
 			<label class={labelClass} for="phone">Phone Number</label>
-			<input class={inputClass} id="phone" name="phone" placeholder="801-111-2222" type="text" />
+			<input class={inputClass} id="phone" name="phone" placeholder="801-111-2222" type="tel" />
 		</div>
-	</div>
-	<div class="flex flex-wrap -mx-3 mb-6">
-		<div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
-			<label class={labelClass} for="organizationName">Organization Name*</label>
+		<div>
+			<label class={labelClass} for="organizationName">
+				Organization Name <span aria-hidden="true" class="text-orange-600">*</span>
+			</label>
 			<input
 				aria-required="true"
 				class={inputClass}
@@ -137,22 +141,40 @@
 				type="text"
 			/>
 		</div>
-		<div class="px-3 w-full md:w-1/2">
+		<div>
 			<label class={labelClass} for="organizationType">Organization Type</label>
-			<select class={inputClass} id="organizationType" name="organizationType">
-				<option value="">Select one</option>
-				<option value="Nonprofit (501c3)">Nonprofit (501(c)(3))</option>
-				<option value="Community organization">Community organization</option>
-				<option value="Mutual aid / grassroots group">Mutual aid / grassroots group</option>
-				<option value="Faith-based organization">Faith-based organization</option>
-				<option value="School / education">School / education</option>
-				<option value="Other">Other</option>
-			</select>
+			<div
+				class="grid grid-cols-[1fr_--spacing(8)] items-center bg-gray-100 rounded-md border border-gray-200 transition-colors focus-within:bg-white focus-within:outline-2 focus-within:-outline-offset-1 focus-within:outline-blue-500"
+			>
+				<select
+					class="col-span-full row-start-1 py-3 px-4 pr-8 w-full text-base text-gray-700 bg-transparent appearance-none focus:outline-hidden"
+					id="organizationType"
+					name="organizationType"
+				>
+					<option value="">Select one</option>
+					<option value="Nonprofit (501c3)">Nonprofit (501(c)(3))</option>
+					<option value="Community organization">Community organization</option>
+					<option value="Mutual aid / grassroots group">Mutual aid / grassroots group</option>
+					<option value="Faith-based organization">Faith-based organization</option>
+					<option value="School / education">School / education</option>
+					<option value="Other">Other</option>
+				</select>
+				<svg
+					viewBox="0 0 8 5"
+					width="8"
+					height="5"
+					fill="none"
+					aria-hidden="true"
+					class="col-start-2 row-start-1 place-self-center text-gray-500 pointer-events-none"
+				>
+					<path d="M.5.5 4 4 7.5.5" stroke="currentColor" />
+				</svg>
+			</div>
 		</div>
-	</div>
-	<div class="flex flex-wrap -mx-3 mb-6">
-		<div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
-			<label class={labelClass} for="city">City / Area*</label>
+		<div>
+			<label class={labelClass} for="city">
+				City / Area <span aria-hidden="true" class="text-orange-600">*</span>
+			</label>
 			<input
 				aria-required="true"
 				class={inputClass}
@@ -163,20 +185,21 @@
 				type="text"
 			/>
 		</div>
-		<div class="px-3 w-full md:w-1/2">
+		<div>
 			<label class={labelClass} for="website">Current Website (if any)</label>
 			<input
 				class={inputClass}
 				id="website"
 				name="website"
 				placeholder="https://example.org"
-				type="text"
+				type="url"
 			/>
 		</div>
-	</div>
-	<div class="flex flex-wrap -mx-3 mb-6">
-		<div class="px-3 w-full">
-			<label class={labelClass} for="mission">Tell us about your organization and the good you do*</label>
+		<div class="sm:col-span-2">
+			<label class={labelClass} for="mission">
+				Tell us about your organization and the good you do
+				<span aria-hidden="true" class="text-orange-600">*</span>
+			</label>
 			<textarea
 				aria-required="true"
 				class={inputClass}
@@ -187,10 +210,11 @@
 				rows={6}
 			></textarea>
 		</div>
-	</div>
-	<div class="flex flex-wrap -mx-3 mb-6">
-		<div class="px-3 w-full">
-			<label class={labelClass} for="goals">What would a website help you accomplish?*</label>
+		<div class="sm:col-span-2">
+			<label class={labelClass} for="goals">
+				What would a website help you accomplish?
+				<span aria-hidden="true" class="text-orange-600">*</span>
+			</label>
 			<textarea
 				aria-required="true"
 				class={inputClass}
@@ -201,47 +225,83 @@
 				rows={6}
 			></textarea>
 		</div>
-	</div>
-	<div class="flex items-start px-3 mb-6">
-		<input
-			class="mt-1 mr-3 w-4 h-4"
-			id="ownership"
-			name="ownership"
-			required
-			type="checkbox"
-		/>
-		<label class="text-sm text-gray-600" for="ownership">
-			I understand that we'll own the website's Git repository and control its deployment, so we can
-			maintain and update it ourselves later.*
-		</label>
-	</div>
-	<div class={clsx('mb-6 flex justify-start', 'xl:justify-end')}>
-		<div class="cf-turnstile" data-sitekey={PUBLIC_TURNSTILE_SITE_KEY} data-theme="light"></div>
-	</div>
-	{#if errorMessage}
-		<p class="px-2 pt-1 text-xs italic text-red-500">
-			{errorMessage}
-		</p>
-	{/if}
-	<div class={clsx('flex justify-start', 'xl:justify-end')}>
-		<button
-			class={clsx(
-				'py-3 px-5 w-full text-base font-medium leading-6 text-white bg-orange-700 rounded-md border border-transparent transition duration-150 ease-in-out',
-				'lg:w-auto',
-				'hover:bg-orange-600',
-				'focus:outline-hidden focus:shadow-outline'
-			)}
-			disabled={isSubmitting}
-			type="submit"
-		>
-			Apply for a free website
-		</button>
+		<div class="flex gap-3 items-start sm:col-span-2">
+			<span class="flex shrink-0 items-center text-sm h-lh">
+				<span class="grid grid-cols-1 group size-5 sm:size-4">
+					<input
+						class="col-start-1 row-start-1 bg-white rounded-sm border border-gray-300 appearance-none checked:border-blue-600 checked:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:border-gray-300 disabled:bg-gray-100 forced-colors:appearance-auto"
+						id="ownership"
+						name="ownership"
+						required
+						type="checkbox"
+					/>
+					<svg
+						viewBox="0 0 14 14"
+						fill="none"
+						aria-hidden="true"
+						class="col-start-1 row-start-1 self-center justify-self-center stroke-white pointer-events-none size-3.5"
+					>
+						<path
+							d="M3 8L6 11L11 3.5"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							class="group-not-has-checked:opacity-0"
+						/>
+					</svg>
+				</span>
+			</span>
+			<label class="text-sm text-gray-600" for="ownership">
+				I understand that we'll own the website's Git repository and control its deployment, so we
+				can maintain and update it ourselves later.
+				<span aria-hidden="true" class="text-orange-600">*</span>
+			</label>
+		</div>
+		<div class={clsx('flex justify-start sm:col-span-2', 'xl:justify-end')}>
+			<div class="cf-turnstile" data-sitekey={PUBLIC_TURNSTILE_SITE_KEY} data-theme="light"></div>
+		</div>
+		{#if errorMessage}
+			<p class="text-sm text-red-600 sm:col-span-2" role="alert">
+				{errorMessage}
+			</p>
+		{/if}
+		<div class={clsx('flex justify-start sm:col-span-2', 'xl:justify-end')}>
+			<button
+				class={clsx(
+					'py-3 px-5 w-full text-base font-medium leading-6 text-white bg-orange-700 rounded-md border border-transparent transition duration-150 ease-in-out',
+					'lg:w-auto',
+					'hover:bg-orange-600',
+					'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-700',
+					'disabled:opacity-60 disabled:cursor-not-allowed'
+				)}
+				disabled={isSubmitting}
+				type="submit"
+			>
+				{isSubmitting ? 'Submitting…' : 'Apply for a free website'}
+			</button>
+		</div>
 	</div>
 </form>
-<div class={submitted ? `visible` : `hidden`}>
-	<h2 class="text-navy-600">Application received!</h2>
-	<p class="text-gray-600">
-		Thank you for telling us about your organization. We review applications every quarter and will
-		be in touch if you're selected. In the meantime, keep up the good work.
-	</p>
+<div class={clsx(!submitted && 'hidden')}>
+	<div class="flex flex-col gap-4 items-center py-6 text-center">
+		<span class="flex justify-center items-center bg-blue-100 rounded-full size-12">
+			<svg
+				class="w-6 h-6 text-blue-600"
+				viewBox="0 0 20 20"
+				fill="currentColor"
+				aria-hidden="true"
+			>
+				<path
+					fill-rule="evenodd"
+					d="M16.704 5.29a1 1 0 010 1.42l-7.5 7.5a1 1 0 01-1.42 0l-3.5-3.5a1 1 0 011.42-1.42l2.79 2.79 6.79-6.79a1 1 0 011.42 0z"
+					clip-rule="evenodd"
+				/>
+			</svg>
+		</span>
+		<h2 class="text-2xl font-semibold tracking-tight text-navy-600">Application received!</h2>
+		<p class="max-w-md text-pretty text-gray-600">
+			Thank you for telling us about your organization. We review applications every quarter and will
+			be in touch if you're selected. In the meantime, keep up the good work.
+		</p>
+	</div>
 </div>

--- a/src/components/free-website-form.svelte
+++ b/src/components/free-website-form.svelte
@@ -157,6 +157,7 @@
 					<option value="Mutual aid / grassroots group">Mutual aid / grassroots group</option>
 					<option value="Faith-based organization">Faith-based organization</option>
 					<option value="School / education">School / education</option>
+					<option value="LGBTQIA+ support organization">LGBTQIA+ support organization</option>
 					<option value="Other">Other</option>
 				</select>
 				<svg
@@ -268,8 +269,9 @@
 		</span>
 		<h2 class="text-2xl font-semibold tracking-tight text-navy-600">Application received!</h2>
 		<p class="max-w-md text-pretty text-gray-600">
-			Thank you for telling us about your organization. We review applications every quarter and will
-			be in touch if you're selected. In the meantime, keep up the good work.
+			Thank you for telling us about your organization. We review applications every quarter and reach
+			out directly to the organization we select. Your application stays on file for future rounds.
+			In the meantime, keep up the good work.
 		</p>
 	</div>
 </div>

--- a/src/components/free-website-form.svelte
+++ b/src/components/free-website-form.svelte
@@ -225,38 +225,6 @@
 				rows={6}
 			></textarea>
 		</div>
-		<div class="flex gap-3 items-start sm:col-span-2">
-			<span class="flex shrink-0 items-center text-sm h-lh">
-				<span class="grid grid-cols-1 group size-5 sm:size-4">
-					<input
-						class="col-start-1 row-start-1 bg-white rounded-sm border border-gray-300 appearance-none checked:border-blue-600 checked:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:border-gray-300 disabled:bg-gray-100 forced-colors:appearance-auto"
-						id="ownership"
-						name="ownership"
-						required
-						type="checkbox"
-					/>
-					<svg
-						viewBox="0 0 14 14"
-						fill="none"
-						aria-hidden="true"
-						class="col-start-1 row-start-1 self-center justify-self-center stroke-white pointer-events-none size-3.5"
-					>
-						<path
-							d="M3 8L6 11L11 3.5"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							class="group-not-has-checked:opacity-0"
-						/>
-					</svg>
-				</span>
-			</span>
-			<label class="text-sm text-gray-600" for="ownership">
-				I understand that we'll own the website's Git repository and control its deployment, so we
-				can maintain and update it ourselves later.
-				<span aria-hidden="true" class="text-orange-600">*</span>
-			</label>
-		</div>
 		<div class={clsx('flex justify-start sm:col-span-2', 'xl:justify-end')}>
 			<div class="cf-turnstile" data-sitekey={PUBLIC_TURNSTILE_SITE_KEY} data-theme="light"></div>
 		</div>

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -13,3 +13,21 @@ export const contactSubmissions = pgTable('contact_submissions', {
 
 export type ContactSubmission = typeof contactSubmissions.$inferSelect;
 export type NewContactSubmission = typeof contactSubmissions.$inferInsert;
+
+export const freeWebsiteApplications = pgTable('free_website_applications', {
+	id: serial('id').primaryKey(),
+	firstName: text('first_name').notNull(),
+	lastName: text('last_name').notNull(),
+	email: text('email').notNull(),
+	phone: text('phone'),
+	organizationName: text('organization_name').notNull(),
+	organizationType: text('organization_type'),
+	website: text('website'),
+	city: text('city').notNull(),
+	mission: text('mission').notNull(),
+	goals: text('goals').notNull(),
+	createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+});
+
+export type FreeWebsiteApplication = typeof freeWebsiteApplications.$inferSelect;
+export type NewFreeWebsiteApplication = typeof freeWebsiteApplications.$inferInsert;

--- a/src/lib/server/telegram.ts
+++ b/src/lib/server/telegram.ts
@@ -68,3 +68,46 @@ export function formatContactMessage(submission: {
 
 	return lines.join('\n');
 }
+
+export function formatFreeWebsiteApplication(application: {
+	firstName: string;
+	lastName: string;
+	email: string;
+	phone?: string | null;
+	organizationName: string;
+	organizationType?: string | null;
+	website?: string | null;
+	city: string;
+	mission: string;
+	goals: string;
+}): string {
+	const lines = [
+		'<b>New Bootpack for Good application</b>',
+		'',
+		`<b>Organization:</b> ${escapeHtml(application.organizationName)}`,
+		`<b>Contact:</b> ${escapeHtml(application.firstName)} ${escapeHtml(application.lastName)}`,
+		`<b>Email:</b> ${escapeHtml(application.email)}`,
+		`<b>City:</b> ${escapeHtml(application.city)}`
+	];
+
+	if (application.organizationType) {
+		lines.push(`<b>Type:</b> ${escapeHtml(application.organizationType)}`);
+	}
+	if (application.phone) {
+		lines.push(`<b>Phone:</b> ${escapeHtml(application.phone)}`);
+	}
+	if (application.website) {
+		lines.push(`<b>Current website:</b> ${escapeHtml(application.website)}`);
+	}
+
+	lines.push(
+		'',
+		'<b>About the organization:</b>',
+		escapeHtml(application.mission),
+		'',
+		'<b>Website goals:</b>',
+		escapeHtml(application.goals)
+	);
+
+	return lines.join('\n');
+}

--- a/src/routes/api/free-website/+server.ts
+++ b/src/routes/api/free-website/+server.ts
@@ -1,0 +1,106 @@
+import { json } from '@sveltejs/kit';
+import { getDb } from '$lib/server/db';
+import { freeWebsiteApplications } from '$lib/server/db/schema';
+import { formatFreeWebsiteApplication, sendTelegramMessage } from '$lib/server/telegram';
+import { verifyTurnstileToken } from '$lib/server/turnstile';
+import type { RequestHandler } from './$types';
+
+export const prerender = false;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_LEN = 5000;
+
+type Payload = {
+	firstName?: unknown;
+	lastName?: unknown;
+	email?: unknown;
+	phone?: unknown;
+	organizationName?: unknown;
+	organizationType?: unknown;
+	website?: unknown;
+	city?: unknown;
+	mission?: unknown;
+	goals?: unknown;
+	turnstileToken?: unknown;
+};
+
+function asTrimmedString(value: unknown, max = MAX_LEN): string | null {
+	if (typeof value !== 'string') return null;
+	const trimmed = value.trim();
+	if (!trimmed || trimmed.length > max) return null;
+	return trimmed;
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : 'unknown error';
+}
+
+export const POST: RequestHandler = async ({ request, getClientAddress }) => {
+	let payload: Payload;
+	try {
+		const parsed: unknown = await request.json();
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			return json({ error: 'Invalid payload' }, { status: 400 });
+		}
+		payload = parsed as Payload;
+	} catch {
+		return json({ error: 'Invalid JSON' }, { status: 400 });
+	}
+
+	const firstName = asTrimmedString(payload.firstName, 200);
+	const lastName = asTrimmedString(payload.lastName, 200);
+	const email = asTrimmedString(payload.email, 320);
+	const phone = asTrimmedString(payload.phone, 50);
+	const organizationName = asTrimmedString(payload.organizationName, 200);
+	const organizationType = asTrimmedString(payload.organizationType, 100);
+	const website = asTrimmedString(payload.website, 500);
+	const city = asTrimmedString(payload.city, 200);
+	const mission = asTrimmedString(payload.mission);
+	const goals = asTrimmedString(payload.goals);
+	const turnstileToken = asTrimmedString(payload.turnstileToken, 2048);
+
+	if (!firstName || !lastName || !email || !organizationName || !city || !mission || !goals) {
+		return json({ error: 'Missing required fields' }, { status: 400 });
+	}
+
+	if (!EMAIL_RE.test(email)) {
+		return json({ error: 'Invalid email' }, { status: 400 });
+	}
+
+	if (!turnstileToken) {
+		return json({ error: 'Captcha token missing' }, { status: 400 });
+	}
+
+	const captchaOk = await verifyTurnstileToken(turnstileToken, getClientAddress());
+	if (!captchaOk) {
+		return json({ error: 'Captcha verification failed' }, { status: 400 });
+	}
+
+	const application = {
+		firstName,
+		lastName,
+		email,
+		phone,
+		organizationName,
+		organizationType,
+		website,
+		city,
+		mission,
+		goals
+	};
+
+	try {
+		await getDb().insert(freeWebsiteApplications).values(application);
+	} catch (err) {
+		console.error('Failed to insert free website application:', errorMessage(err));
+		return json({ error: 'Could not save application' }, { status: 500 });
+	}
+
+	try {
+		await sendTelegramMessage(formatFreeWebsiteApplication(application));
+	} catch (err) {
+		console.error('Failed to send Telegram notification:', errorMessage(err));
+	}
+
+	return json({ ok: true });
+};

--- a/src/routes/bootpack-for-good/+page.svelte
+++ b/src/routes/bootpack-for-good/+page.svelte
@@ -10,7 +10,7 @@
 		},
 		{
 			title: 'We pick one organization each quarter',
-			body: 'Every quarter we choose one Salt Lake–area organization from the applications we receive and reach out to get started.'
+			body: 'Every quarter we choose one Salt Lake–area organization based on need and the impact a new website could have, then reach out to get started.'
 		},
 		{
 			title: 'We design and build it with you',
@@ -47,6 +47,10 @@
 		{
 			q: 'How often do you choose an organization?',
 			a: 'We review applications and select one organization every quarter, so it’s worth applying even if it isn’t your turn yet.'
+		},
+		{
+			q: 'How do you decide who gets selected?',
+			a: 'We weigh need and impact. This is for nonprofits and community organizations that genuinely can’t afford a professionally built website, so we prioritize the groups where a new site will do the most good for the community. It isn’t meant for well-funded businesses looking for free work.'
 		},
 		{
 			q: 'What does "up to five pages" mean?',
@@ -195,9 +199,11 @@
 				Who can apply
 			</h2>
 			<p class="mx-auto mt-4 text-pretty text-gray-600">
-				We're looking for organizations based in or serving the greater Salt Lake City area that are
-				making their community better. If you're doing good and a better website would help you do
-				more of it, we'd love to hear from you.
+				We're looking for nonprofits and community organizations based in or serving the greater Salt
+				Lake City area that are making their community better but don't have the budget for a
+				professionally built website. We choose each quarter's recipient based on need and the impact a
+				new site could have — so this is for mission-driven groups doing a lot with a little, not
+				well-funded businesses looking for something free.
 			</p>
 		</div>
 		<ul role="list" class="grid gap-4 mt-10 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/routes/bootpack-for-good/+page.svelte
+++ b/src/routes/bootpack-for-good/+page.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+	import clsx from 'clsx';
+	import FreeWebsiteForm from '../../components/free-website-form.svelte';
+	import Seo from '../../components/seo.svelte';
+
+	const steps = [
+		{
+			title: 'Tell us about your work',
+			body: "Fill out the short form below. Share your mission, who you serve, and what you're hoping a website can do for you."
+		},
+		{
+			title: 'We pick one organization each quarter',
+			body: 'Every quarter we choose one Salt Lake–area organization from the applications we receive and reach out to get started.'
+		},
+		{
+			title: 'We design and build it with you',
+			body: 'We build up to five pages in a clean, brochure-style site that matches your brand — think Home, About, Programs, and Contact.'
+		},
+		{
+			title: 'You own it, forever',
+			body: 'We hand over the Git repository and you control where it deploys. Update it later with Claude Code, ChatGPT, or any tool you like.'
+		}
+	];
+
+	const included = [
+		'A brand-matched, mobile-friendly website',
+		'Up to five pages (for example: Home, About, Programs, Contact, and one more)',
+		'A Git repository that belongs to you',
+		'Freedom to host and deploy wherever you want',
+		'The ability to make edits later with AI tools like Claude Code or ChatGPT',
+		'Built by the Bootpack Digital team — at no cost to you'
+	];
+
+	const faqs = [
+		{
+			q: 'Is it really free?',
+			a: "Yes. There's no cost and no catch. It's how we give back to the Salt Lake community we're part of."
+		},
+		{
+			q: 'How often do you choose an organization?',
+			a: 'We review applications and select one organization every quarter, so it’s worth applying even if it isn’t your turn yet.'
+		},
+		{
+			q: 'What does "up to five pages" mean?',
+			a: 'A focused, brochure-style site — typically a home page plus pages like About, Programs or Services, and Contact. We’ll figure out the right mix together.'
+		},
+		{
+			q: 'Do we have to know how to code to maintain it?',
+			a: 'No. Because you own the Git repository, you can make updates yourself using AI tools like Claude Code or ChatGPT, hand it to a volunteer, or hire anyone you like.'
+		}
+	];
+</script>
+
+<Seo
+	title="Bootpack for Good | Free websites for Salt Lake organizations doing good"
+	description="Each quarter, Bootpack Digital builds a free, brand-matched website for one Salt Lake–area nonprofit or community organization doing good. You own the code and control the deployment. Apply today."
+	canonical="/bootpack-for-good"
+/>
+
+<div class="relative bg-blue-50">
+	<div
+		class="absolute inset-0 w-full h-full"
+		style="background-image: url('/images/blue-topo.svg'); background-size: 600px 600px; background-repeat: repeat;"
+		aria-hidden="true"
+	></div>
+	<div class="relative py-16 px-4 mx-auto max-w-4xl text-center sm:px-6 lg:py-24 lg:px-8">
+		<p class="mb-3 text-sm font-bold tracking-widest text-orange-700 uppercase">Bootpack for Good</p>
+		<h1
+			class={clsx(
+				'font-bold leading-tight text-navy-500 text-[2rem]',
+				'md:text-4xl',
+				'xl:text-5xl'
+			)}
+		>
+			Free websites for Salt Lake organizations
+			<span class="text-blue-500">doing good</span>
+		</h1>
+		<p class="mx-auto mt-6 max-w-2xl text-base leading-normal text-blue-600 md:text-xl">
+			Every quarter, we partner with one local nonprofit or community organization to design and
+			build a website that matches their brand — completely free. You walk away owning the code and
+			controlling where it lives.
+		</p>
+		<div class="flex justify-center mt-8">
+			<a
+				class="flex justify-center items-center py-3 px-5 text-base font-medium leading-6 text-white bg-orange-700 rounded-md border border-transparent transition duration-150 ease-in-out hover:bg-orange-600 focus:outline-hidden focus:shadow-outline"
+				href="#apply"
+			>
+				Apply for a free website
+			</a>
+		</div>
+	</div>
+</div>
+
+<section class="px-4 py-16 bg-white sm:px-6 lg:py-20 lg:px-8">
+	<div class="mx-auto max-w-5xl">
+		<h2 class="text-2xl font-bold text-center text-navy-600 md:text-3xl">How it works</h2>
+		<div class="grid gap-8 mt-12 sm:grid-cols-2">
+			{#each steps as step, i (step.title)}
+				<div class="flex gap-4 items-start">
+					<div
+						class="flex shrink-0 justify-center items-center w-10 h-10 text-lg font-bold text-white bg-blue-600 rounded-full"
+						aria-hidden="true"
+					>
+						{i + 1}
+					</div>
+					<div>
+						<h3 class="text-lg font-bold text-navy-600">{step.title}</h3>
+						<p class="mt-1 text-gray-600">{step.body}</p>
+					</div>
+				</div>
+			{/each}
+		</div>
+	</div>
+</section>
+
+<section class="px-4 py-16 bg-blue-50 sm:px-6 lg:py-20 lg:px-8">
+	<div class="grid gap-12 mx-auto max-w-5xl lg:grid-cols-2 lg:items-center">
+		<div>
+			<h2 class="text-2xl font-bold text-navy-600 md:text-3xl">What you get</h2>
+			<ul class="mt-6 space-y-3">
+				{#each included as item (item)}
+					<li class="flex gap-3 items-start text-gray-700">
+						<svg
+							class="shrink-0 mt-1 w-5 h-5 text-orange-600"
+							viewBox="0 0 20 20"
+							fill="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								fill-rule="evenodd"
+								d="M16.704 5.29a1 1 0 010 1.42l-7.5 7.5a1 1 0 01-1.42 0l-3.5-3.5a1 1 0 011.42-1.42l2.79 2.79 6.79-6.79a1 1 0 011.42 0z"
+								clip-rule="evenodd"
+							/>
+						</svg>
+						<span>{item}</span>
+					</li>
+				{/each}
+			</ul>
+		</div>
+		<div class="p-8 bg-white rounded-xl border border-navy-100 shadow-sm">
+			<h3 class="text-xl font-bold text-navy-600">You own it — not us</h3>
+			<p class="mt-3 text-gray-600">
+				This isn't a rented website you have to keep paying for. We build everything in a Git
+				repository that becomes yours, and you control where and how it's deployed.
+			</p>
+			<p class="mt-3 text-gray-600">
+				That means no lock-in. Down the road you can update copy, add pages, or redesign the whole
+				thing using modern AI tools like
+				<span class="font-semibold text-navy-600">Claude Code</span> or
+				<span class="font-semibold text-navy-600">ChatGPT</span> — or hand it off to any developer
+				you choose.
+			</p>
+		</div>
+	</div>
+</section>
+
+<section class="px-4 py-16 bg-white sm:px-6 lg:py-20 lg:px-8">
+	<div class="mx-auto max-w-3xl text-center">
+		<h2 class="text-2xl font-bold text-navy-600 md:text-3xl">Who can apply</h2>
+		<p class="mt-4 text-gray-600">
+			We're looking for organizations based in or serving the greater Salt Lake City area that are
+			making their community better — nonprofits, community groups, mutual aid efforts, and
+			organizations supporting marginalized communities. If you're doing good and a better website
+			would help you do more of it, we'd love to hear from you.
+		</p>
+	</div>
+</section>
+
+<section id="apply" class="px-4 py-16 bg-blue-50 sm:px-6 lg:py-20 lg:px-8 scroll-mt-20">
+	<div class="mx-auto max-w-3xl">
+		<h2 class="text-2xl font-bold text-center text-navy-600 md:text-3xl">Apply for a free website</h2>
+		<p class="mx-auto mt-4 mb-4 max-w-2xl text-center text-gray-600">
+			Tell us about your organization. There's no deadline — we review applications and choose a new
+			organization every quarter.
+		</p>
+		<div class="p-6 bg-white rounded-xl border border-navy-100 shadow-sm sm:p-8">
+			<FreeWebsiteForm />
+		</div>
+	</div>
+</section>
+
+<section class="px-4 py-16 bg-white sm:px-6 lg:py-20 lg:px-8">
+	<div class="mx-auto max-w-3xl">
+		<h2 class="text-2xl font-bold text-center text-navy-600 md:text-3xl">Frequently asked questions</h2>
+		<dl class="mt-10 space-y-8">
+			{#each faqs as faq (faq.q)}
+				<div>
+					<dt class="text-lg font-bold text-navy-600">{faq.q}</dt>
+					<dd class="mt-2 text-gray-600">{faq.a}</dd>
+				</div>
+			{/each}
+		</dl>
+	</div>
+</section>

--- a/src/routes/bootpack-for-good/+page.svelte
+++ b/src/routes/bootpack-for-good/+page.svelte
@@ -31,6 +31,14 @@
 		'Built by the Bootpack Digital team — at no cost to you'
 	];
 
+	const orgTypes = [
+		'Nonprofits (501(c)(3))',
+		'Community organizations',
+		'Mutual aid & grassroots groups',
+		'Faith-based organizations',
+		'Schools & education'
+	];
+
 	const faqs = [
 		{
 			q: 'Is it really free?',
@@ -51,6 +59,21 @@
 	];
 </script>
 
+{#snippet check(extra: string)}
+	<svg
+		class={clsx('shrink-0 w-5 h-5 text-orange-600', extra)}
+		viewBox="0 0 20 20"
+		fill="currentColor"
+		aria-hidden="true"
+	>
+		<path
+			fill-rule="evenodd"
+			d="M16.704 5.29a1 1 0 010 1.42l-7.5 7.5a1 1 0 01-1.42 0l-3.5-3.5a1 1 0 011.42-1.42l2.79 2.79 6.79-6.79a1 1 0 011.42 0z"
+			clip-rule="evenodd"
+		/>
+	</svg>
+{/snippet}
+
 <Seo
 	title="Bootpack for Good | Free websites for Salt Lake organizations doing good"
 	description="Each quarter, Bootpack Digital builds a free, brand-matched website for one Salt Lake–area nonprofit or community organization doing good. You own the code and control the deployment. Apply today."
@@ -63,37 +86,57 @@
 		style="background-image: url('/images/blue-topo.svg'); background-size: 600px 600px; background-repeat: repeat;"
 		aria-hidden="true"
 	></div>
-	<div class="relative py-16 px-4 mx-auto max-w-4xl text-center sm:px-6 lg:py-24 lg:px-8">
-		<p class="mb-3 text-sm font-bold tracking-widest text-orange-700 uppercase">Bootpack for Good</p>
-		<h1
-			class={clsx(
-				'font-bold leading-tight text-navy-500 text-[2rem]',
-				'md:text-4xl',
-				'xl:text-5xl'
-			)}
-		>
-			Free websites for Salt Lake organizations
-			<span class="text-blue-500">doing good</span>
-		</h1>
-		<p class="mx-auto mt-6 max-w-2xl text-base leading-normal text-blue-600 md:text-xl">
-			Every quarter, we partner with one local nonprofit or community organization to design and
-			build a website that matches their brand — completely free. You walk away owning the code and
-			controlling where it lives.
-		</p>
-		<div class="flex justify-center mt-8">
-			<a
-				class="flex justify-center items-center py-3 px-5 text-base font-medium leading-6 text-white bg-orange-700 rounded-md border border-transparent transition duration-150 ease-in-out hover:bg-orange-600 focus:outline-hidden focus:shadow-outline"
-				href="#apply"
+	<div
+		class="grid relative gap-12 items-center px-4 py-16 mx-auto max-w-6xl sm:px-6 lg:grid-cols-2 lg:py-24 lg:px-8"
+	>
+		<div>
+			<p class="text-sm font-bold tracking-widest text-orange-700 uppercase">Bootpack for Good</p>
+			<h1
+				class="mt-3 max-w-[18ch] text-balance text-[2rem] font-semibold tracking-tight text-navy-500 md:text-4xl xl:text-5xl"
 			>
-				Apply for a free website
-			</a>
+				Free websites for Salt Lake organizations
+				<span class="text-blue-500">doing good</span>
+			</h1>
+			<p class="mt-6 max-w-xl text-pretty text-base text-blue-700 md:text-lg">
+				Every quarter, we partner with one local nonprofit or community organization to design and
+				build a website that matches their brand — completely free. You walk away owning the code.
+			</p>
+			<div class="flex flex-wrap gap-5 items-center mt-8">
+				<a
+					class="flex justify-center items-center py-3 px-5 text-base font-medium leading-6 text-white bg-orange-700 rounded-md border border-transparent transition duration-150 ease-in-out hover:bg-orange-600 focus:outline-hidden focus:shadow-outline"
+					href="#apply"
+				>
+					Apply for a free website
+				</a>
+				<a
+					class="text-base font-semibold text-blue-700 transition-colors hover:text-blue-600"
+					href="#how"
+				>
+					See how it works
+				</a>
+			</div>
+		</div>
+		<div class="p-8 bg-white rounded-xl border shadow-sm border-navy-100">
+			<p class="text-sm font-bold tracking-widest text-orange-700 uppercase">
+				What you walk away with
+			</p>
+			<ul role="list" class="mt-4 space-y-3">
+				{#each included.slice(0, 4) as item (item)}
+					<li class="flex gap-3 items-start text-gray-700">
+						{@render check('mt-1')}
+						<span>{item}</span>
+					</li>
+				{/each}
+			</ul>
 		</div>
 	</div>
 </div>
 
-<section class="px-4 py-16 bg-white sm:px-6 lg:py-20 lg:px-8">
+<section id="how" class="px-4 py-16 bg-white sm:px-6 lg:py-20 lg:px-8 scroll-mt-20">
 	<div class="mx-auto max-w-5xl">
-		<h2 class="text-2xl font-bold text-center text-navy-600 md:text-3xl">How it works</h2>
+		<h2 class="text-2xl font-semibold tracking-tight text-balance text-center text-navy-600 md:text-3xl">
+			How it works
+		</h2>
 		<div class="grid gap-8 mt-12 sm:grid-cols-2">
 			{#each steps as step, i (step.title)}
 				<div class="flex gap-4 items-start">
@@ -104,8 +147,8 @@
 						{i + 1}
 					</div>
 					<div>
-						<h3 class="text-lg font-bold text-navy-600">{step.title}</h3>
-						<p class="mt-1 text-gray-600">{step.body}</p>
+						<h3 class="text-lg font-semibold text-navy-600">{step.title}</h3>
+						<p class="mt-1 text-pretty text-gray-600">{step.body}</p>
 					</div>
 				</div>
 			{/each}
@@ -116,34 +159,25 @@
 <section class="px-4 py-16 bg-blue-50 sm:px-6 lg:py-20 lg:px-8">
 	<div class="grid gap-12 mx-auto max-w-5xl lg:grid-cols-2 lg:items-center">
 		<div>
-			<h2 class="text-2xl font-bold text-navy-600 md:text-3xl">What you get</h2>
-			<ul class="mt-6 space-y-3">
+			<h2 class="text-2xl font-semibold tracking-tight text-balance text-navy-600 md:text-3xl">
+				What you get
+			</h2>
+			<ul class="mt-6 space-y-3" role="list">
 				{#each included as item (item)}
 					<li class="flex gap-3 items-start text-gray-700">
-						<svg
-							class="shrink-0 mt-1 w-5 h-5 text-orange-600"
-							viewBox="0 0 20 20"
-							fill="currentColor"
-							aria-hidden="true"
-						>
-							<path
-								fill-rule="evenodd"
-								d="M16.704 5.29a1 1 0 010 1.42l-7.5 7.5a1 1 0 01-1.42 0l-3.5-3.5a1 1 0 011.42-1.42l2.79 2.79 6.79-6.79a1 1 0 011.42 0z"
-								clip-rule="evenodd"
-							/>
-						</svg>
+						{@render check('mt-1')}
 						<span>{item}</span>
 					</li>
 				{/each}
 			</ul>
 		</div>
 		<div class="p-8 bg-white rounded-xl border border-navy-100 shadow-sm">
-			<h3 class="text-xl font-bold text-navy-600">You own it — not us</h3>
-			<p class="mt-3 text-gray-600">
+			<h3 class="text-xl font-semibold text-navy-600">You own it — not us</h3>
+			<p class="mt-3 text-pretty text-gray-600">
 				This isn't a rented website you have to keep paying for. We build everything in a Git
 				repository that becomes yours, and you control where and how it's deployed.
 			</p>
-			<p class="mt-3 text-gray-600">
+			<p class="mt-3 text-pretty text-gray-600">
 				That means no lock-in. Down the road you can update copy, add pages, or redesign the whole
 				thing using modern AI tools like
 				<span class="font-semibold text-navy-600">Claude Code</span> or
@@ -155,21 +189,34 @@
 </section>
 
 <section class="px-4 py-16 bg-white sm:px-6 lg:py-20 lg:px-8">
-	<div class="mx-auto max-w-3xl text-center">
-		<h2 class="text-2xl font-bold text-navy-600 md:text-3xl">Who can apply</h2>
-		<p class="mt-4 text-gray-600">
-			We're looking for organizations based in or serving the greater Salt Lake City area that are
-			making their community better — nonprofits, community groups, mutual aid efforts, and
-			organizations supporting marginalized communities. If you're doing good and a better website
-			would help you do more of it, we'd love to hear from you.
-		</p>
+	<div class="mx-auto max-w-5xl">
+		<div class="mx-auto max-w-2xl text-center">
+			<h2 class="text-2xl font-semibold tracking-tight text-balance text-navy-600 md:text-3xl">
+				Who can apply
+			</h2>
+			<p class="mx-auto mt-4 text-pretty text-gray-600">
+				We're looking for organizations based in or serving the greater Salt Lake City area that are
+				making their community better. If you're doing good and a better website would help you do
+				more of it, we'd love to hear from you.
+			</p>
+		</div>
+		<ul role="list" class="grid gap-4 mt-10 sm:grid-cols-2 lg:grid-cols-3">
+			{#each orgTypes as type (type)}
+				<li class="flex gap-3 items-center p-5 bg-blue-50 rounded-xl border border-navy-100">
+					{@render check('')}
+					<span class="font-semibold text-navy-600">{type}</span>
+				</li>
+			{/each}
+		</ul>
 	</div>
 </section>
 
 <section id="apply" class="px-4 py-16 bg-blue-50 sm:px-6 lg:py-20 lg:px-8 scroll-mt-20">
 	<div class="mx-auto max-w-3xl">
-		<h2 class="text-2xl font-bold text-center text-navy-600 md:text-3xl">Apply for a free website</h2>
-		<p class="mx-auto mt-4 mb-4 max-w-2xl text-center text-gray-600">
+		<h2 class="text-2xl font-semibold tracking-tight text-balance text-center text-navy-600 md:text-3xl">
+			Apply for a free website
+		</h2>
+		<p class="mx-auto mt-4 mb-4 max-w-2xl text-pretty text-center text-gray-600">
 			Tell us about your organization. There's no deadline — we review applications and choose a new
 			organization every quarter.
 		</p>
@@ -181,14 +228,32 @@
 
 <section class="px-4 py-16 bg-white sm:px-6 lg:py-20 lg:px-8">
 	<div class="mx-auto max-w-3xl">
-		<h2 class="text-2xl font-bold text-center text-navy-600 md:text-3xl">Frequently asked questions</h2>
-		<dl class="mt-10 space-y-8">
+		<h2 class="text-2xl font-semibold tracking-tight text-balance text-center text-navy-600 md:text-3xl">
+			Frequently asked questions
+		</h2>
+		<div class="mt-10 rounded-xl border divide-y divide-navy-100 border-navy-100">
 			{#each faqs as faq (faq.q)}
-				<div>
-					<dt class="text-lg font-bold text-navy-600">{faq.q}</dt>
-					<dd class="mt-2 text-gray-600">{faq.a}</dd>
-				</div>
+				<details class="group">
+					<summary
+						class="flex gap-4 justify-between items-center px-6 py-5 list-none cursor-pointer [&::-webkit-details-marker]:hidden"
+					>
+						<span class="text-lg font-semibold text-navy-600">{faq.q}</span>
+						<svg
+							class="shrink-0 w-5 h-5 transition-transform duration-200 text-navy-400 group-open:rotate-180"
+							viewBox="0 0 20 20"
+							fill="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								fill-rule="evenodd"
+								d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
+								clip-rule="evenodd"
+							/>
+						</svg>
+					</summary>
+					<p class="px-6 pb-5 text-pretty text-gray-600">{faq.a}</p>
+				</details>
 			{/each}
-		</dl>
+		</div>
 	</div>
 </section>

--- a/src/routes/bootpack-for-good/+page.svelte
+++ b/src/routes/bootpack-for-good/+page.svelte
@@ -14,7 +14,7 @@
 		},
 		{
 			title: 'We design and build it with you',
-			body: 'We build up to five pages in a clean, brochure-style site that matches your brand — think Home, About, Programs, and Contact.'
+			body: 'We build up to five pages in a clean, brochure-style site that matches your brand. Think Home, About, Programs, and Contact.'
 		},
 		{
 			title: 'You own it, forever',
@@ -24,11 +24,11 @@
 
 	const included = [
 		'A brand-matched, mobile-friendly website',
-		'Up to five pages (for example: Home, About, Programs, Contact, and one more)',
-		'A Git repository that belongs to you',
+		'Up to five pages (for example: Home, About, Programs, and Contact)',
+		'All your website files, yours to keep (a Git repository you own)',
 		'Freedom to host and deploy wherever you want',
 		'The ability to make edits later with AI tools like Claude Code or ChatGPT',
-		'Built by the Bootpack Digital team — at no cost to you'
+		'Built by the Bootpack Digital team, at no cost to you'
 	];
 
 	const orgTypes = [
@@ -36,7 +36,8 @@
 		'Community organizations',
 		'Mutual aid & grassroots groups',
 		'Faith-based organizations',
-		'Schools & education'
+		'Schools & education',
+		'LGBTQIA+ support organizations'
 	];
 
 	const faqs = [
@@ -54,7 +55,7 @@
 		},
 		{
 			q: 'What does "up to five pages" mean?',
-			a: 'A focused, brochure-style site — typically a home page plus pages like About, Programs or Services, and Contact. We’ll figure out the right mix together.'
+			a: 'A focused, brochure-style site. Typically that’s a home page plus pages like About, Programs or Services, and Contact. We’ll figure out the right mix together.'
 		},
 		{
 			q: 'Do we have to know how to code to maintain it?',
@@ -102,8 +103,8 @@
 				<span class="text-blue-500">doing good</span>
 			</h1>
 			<p class="mt-6 max-w-xl text-pretty text-base text-blue-700 md:text-lg">
-				Every quarter, we partner with one local nonprofit or community organization to design and
-				build a website that matches their brand — completely free. You walk away owning the code.
+				The work you do deserves a website that helps, not one that holds you back. Each quarter, we
+				partner with one local nonprofit or community organization to design and build a brand-matched site, completely free. You walk away owning it outright, with no monthly fees or strings. We're a Salt Lake studio that builds for paying clients, and we give one site away every quarter.
 			</p>
 			<div class="flex flex-wrap gap-5 items-center mt-8">
 				<a
@@ -174,9 +175,17 @@
 					</li>
 				{/each}
 			</ul>
+			<p class="mt-6">
+				<a
+					class="text-base font-semibold text-blue-700 transition-colors hover:text-blue-600"
+					href="/work"
+				>
+					See examples of our work →
+				</a>
+			</p>
 		</div>
 		<div class="p-8 bg-white rounded-xl border border-navy-100 shadow-sm">
-			<h3 class="text-xl font-semibold text-navy-600">You own it — not us</h3>
+			<h3 class="text-xl font-semibold text-navy-600">You own it, not us</h3>
 			<p class="mt-3 text-pretty text-gray-600">
 				This isn't a rented website you have to keep paying for. We build everything in a Git
 				repository that becomes yours, and you control where and how it's deployed.
@@ -185,7 +194,7 @@
 				That means no lock-in. Down the road you can update copy, add pages, or redesign the whole
 				thing using modern AI tools like
 				<span class="font-semibold text-navy-600">Claude Code</span> or
-				<span class="font-semibold text-navy-600">ChatGPT</span> — or hand it off to any developer
+				<span class="font-semibold text-navy-600">ChatGPT</span>, or hand it off to any developer
 				you choose.
 			</p>
 		</div>
@@ -202,7 +211,7 @@
 				We're looking for nonprofits and community organizations based in or serving the greater Salt
 				Lake City area that are making their community better but don't have the budget for a
 				professionally built website. We choose each quarter's recipient based on need and the impact a
-				new site could have — so this is for mission-driven groups doing a lot with a little, not
+				new site could have. This is for mission-driven groups doing a lot with a little, not
 				well-funded businesses looking for something free.
 			</p>
 		</div>
@@ -223,8 +232,8 @@
 			Apply for a free website
 		</h2>
 		<p class="mx-auto mt-4 mb-4 max-w-2xl text-pretty text-center text-gray-600">
-			Tell us about your organization. There's no deadline — we review applications and choose a new
-			organization every quarter.
+			Tell us about your organization. There's no deadline. We review applications and choose a new
+			organization every quarter. If you're not selected right away, your application stays in the running for future quarters.
 		</p>
 		<div class="p-6 bg-white rounded-xl border border-navy-100 shadow-sm sm:p-8">
 			<FreeWebsiteForm />

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -37,6 +37,10 @@
 							rel="noopener noreferrer">available job listings</a
 						>.
 					</p>
+					<p>
+						Run a Salt Lake–area nonprofit or community organization? We give away a free
+						website every quarter through <a href="/bootpack-for-good">Bootpack for Good</a>.
+					</p>
 					<div>
 						<a
 							class="inline-flex py-3 px-5 text-base font-medium leading-6 text-white bg-blue-600 rounded-md border border-transparent transition duration-150 ease-in-out lg:w-auto hover:bg-blue-500 focus:outline-hidden focus:shadow-outline"


### PR DESCRIPTION
## Summary

Introduces **Bootpack for Good** — a program where, once a quarter, we build a free, brand-matched brochure-style website (up to five pages) for one Salt Lake–area nonprofit or community organization doing good. A key promise emphasized throughout: the recipient owns the Git repository and controls the deployment, so they can maintain and update it later with tools like Claude Code or ChatGPT.

- **New landing page** at `/bootpack-for-good` (`src/routes/bootpack-for-good/+page.svelte`) with hero, how-it-works, what's-included, an "you own it — not us" ownership callout, eligibility, an application form, and FAQ. Uses the existing brand palette and topo hero pattern.
- **New application form** (`src/components/free-website-form.svelte`) collecting contact info, organization name/type, city, current website, mission, and website goals, plus a required ownership acknowledgment. Mirrors the contact form's submit flow, Cloudflare Turnstile, and `PUBLIC_TEST_CONTACT_FORM` test short-circuit.
- **New API route** `src/routes/api/free-website/+server.ts` — validates input, verifies Turnstile, inserts into a new `free_website_applications` table, and sends a Telegram notification (`formatFreeWebsiteApplication`). Same patterns as `/api/contact`.
- **DB**: new `free_website_applications` table in the Drizzle schema + generated migration `drizzle/0001_naive_aaron_stack.sql`.
- **Navigation**: linked from the footer (per request — not added to the main header nav).
- **Docs**: updated `CLAUDE.md` to describe the new route, endpoint, table, and the shared test env var.

## Test plan

- [x] `bun run build` succeeds and the new page prerenders
- [x] `bun run test:e2e` — all 3 Playwright tests pass, including a new `test-free-website-form.test.ts` and the new page added to the `around-the-world` smoke test
- [x] Type-check: no new errors introduced (remaining `svelte-check` errors are pre-existing/environmental)
- [x] Visually verified desktop + mobile layouts via screenshots
- [ ] Confirm `free_website_applications` migration is applied in environments before launch
- [ ] Verify Telegram notification formatting against a real submission

https://claude.ai/code/session_01XoKFr7pMG9Z4F3Dcc6fWpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoKFr7pMG9Z4F3Dcc6fWpY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched "Bootpack for Good" program with a dedicated landing page featuring application form, eligibility information, and FAQ
  * Added free website application form with validation and success confirmation message
  * Updated footer navigation to link to the new program

* **Tests**
  * Added end-to-end tests for the new landing page and application form workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michaelbonner/bootpack-digital/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->