### PR TITLE
Tighten Energy Safe Kids case study copy and add metrics

### DIFF
--- a/src/lib/data/case-studies.ts
+++ b/src/lib/data/case-studies.ts
@@ -49,20 +49,20 @@ export const caseStudies: CaseStudy[] = [
 		slug: 'energy-safe-kids',
 		title: 'Energy Safe Kids',
 		description:
-			'We built a multi-tenant platform for the National Energy Foundation that lets one team manage dozens of branded educational sites for utility partners, without the copy-paste nightmare.',
+			'We built a multi-tenant platform for the National Energy Foundation that lets one team manage 30+ branded educational sites for utility partners, without the copy-paste nightmare.',
 		image: EnergySafeKidsHome,
 		link: 'https://energysafekids.org',
 		features: [
 			{
 				title: 'Multi-Tenant Architecture',
 				description:
-					'One codebase, dozens of sites. When NEF pushes an update, every partner site gets it instantly; no deployment marathons required.',
+					'One codebase, 30+ sites. When NEF pushes an update, every partner site gets it instantly — no deployment marathons required.',
 				icon: 'lightning' // Using lightning as a metaphor for power/energy
 			},
 			{
 				title: 'White-Label Branding',
 				description:
-					'Each utility partner gets a site that looks and feels like their own, right down to brand colors, logos, and regional content.',
+					'Each utility partner gets a site that looks and feels like their own, right down to brand colors, logos, and regional content. Partners get the credit; NEF skips the rebuild.',
 				icon: 'users'
 			}
 		],
@@ -79,7 +79,7 @@ export const caseStudies: CaseStudy[] = [
 				title: 'Same Platform, Different Brand',
 				content: [
 					"Here's the cool part: even though everything runs on one platform, each partner's site feels completely custom. Rocky Mountain Power visitors see RMP branding, colors, and local info. Pacific Power visitors get theirs. It all happens automatically.",
-					"Adding a new utility partner used to mean building a whole new site. Now it's closer to flipping a switch; upload their logo, set their colors, and they're live. NEF can onboard new partners in a fraction of the time it used to take."
+					"Adding a new utility partner used to mean building a whole new site — about four weeks of work. Now it's closer to flipping a switch: upload their logo, set their colors, and they're live in an hour. That's how NEF has onboarded 30 partners."
 				],
 				images: [RockyMountainPowerHome, RockyMountainPowerAbout]
 			},
@@ -87,7 +87,7 @@ export const caseStudies: CaseStudy[] = [
 				title: 'Growing Up: Energy Safe Leaders',
 				content: [
 					"The original platform was built for younger kids, but NEF wanted to reach high schoolers too. Rather than start from scratch, we built 'Energy Safe Leaders' on top of the same tech stack.",
-					"It's a more mature look and feel with age-appropriate content, but under the hood it shares the same CMS and multi-tenant architecture. One platform, two audiences, and room to grow into more."
+					"It's a more mature look and feel with age-appropriate content, but under the hood it shares the same CMS and multi-tenant architecture. One platform, two audiences, and room to grow."
 				],
 				images: [EnergySafeLeadersHome, EnergySafeLeadersStudentResources]
 			}

--- a/src/lib/data/case-studies.ts
+++ b/src/lib/data/case-studies.ts
@@ -49,14 +49,14 @@ export const caseStudies: CaseStudy[] = [
 		slug: 'energy-safe-kids',
 		title: 'Energy Safe Kids',
 		description:
-			'We built a multi-tenant platform for the National Energy Foundation that lets one team manage 30+ branded educational sites for utility partners, without the copy-paste nightmare.',
+			'We built a single platform for the National Energy Foundation that lets one team manage 30+ branded educational sites for utility partners, without the copy-paste nightmare.',
 		image: EnergySafeKidsHome,
 		link: 'https://energysafekids.org',
 		features: [
 			{
-				title: 'Multi-Tenant Architecture',
+				title: 'One Platform, Many Sites',
 				description:
-					'One codebase, 30+ sites. When NEF pushes an update, every partner site gets it instantly. No deployment marathons required.',
+					'All 30+ sites run on one shared system. When NEF pushes an update, every partner site gets it instantly. No deployment marathons required.',
 				icon: 'lightning' // Using lightning as a metaphor for power/energy
 			},
 			{
@@ -87,7 +87,7 @@ export const caseStudies: CaseStudy[] = [
 				title: 'Growing Up: Energy Safe Leaders',
 				content: [
 					"The original platform was built for younger kids, but NEF wanted to reach high schoolers too. Rather than start from scratch, we built 'Energy Safe Leaders' on top of the same tech stack.",
-					"It's a more mature look and feel with age-appropriate content, but under the hood it shares the same CMS and multi-tenant architecture. One platform, two audiences, and room to grow."
+					"It's a more mature look and feel with age-appropriate content, but under the hood it shares the same CMS and infrastructure. One platform, two audiences, and room to grow."
 				],
 				images: [EnergySafeLeadersHome, EnergySafeLeadersStudentResources]
 			}

--- a/src/lib/data/case-studies.ts
+++ b/src/lib/data/case-studies.ts
@@ -56,7 +56,7 @@ export const caseStudies: CaseStudy[] = [
 			{
 				title: 'Multi-Tenant Architecture',
 				description:
-					'One codebase, 30+ sites. When NEF pushes an update, every partner site gets it instantly — no deployment marathons required.',
+					'One codebase, 30+ sites. When NEF pushes an update, every partner site gets it instantly. No deployment marathons required.',
 				icon: 'lightning' // Using lightning as a metaphor for power/energy
 			},
 			{
@@ -79,7 +79,7 @@ export const caseStudies: CaseStudy[] = [
 				title: 'Same Platform, Different Brand',
 				content: [
 					"Here's the cool part: even though everything runs on one platform, each partner's site feels completely custom. Rocky Mountain Power visitors see RMP branding, colors, and local info. Pacific Power visitors get theirs. It all happens automatically.",
-					"Adding a new utility partner used to mean building a whole new site — about four weeks of work. Now it's closer to flipping a switch: upload their logo, set their colors, and they're live in an hour. That's how NEF has onboarded 30 partners."
+					"Adding a new utility partner used to mean building a whole new site, about four weeks of work. Now it's closer to flipping a switch: upload their logo, set their colors, and they're live in an hour. That's how NEF has onboarded 30 partners."
 				],
 				images: [RockyMountainPowerHome, RockyMountainPowerAbout]
 			},


### PR DESCRIPTION
## What changed

Copy edits to the Energy Safe Kids case study (`src/lib/data/case-studies.ts`), driven by a copy-editing pass (Prove It / Specificity / So What sweeps). Content-only — no structural or type changes.

- **Concrete numbers replace vague quantities:** "dozens of sites" → "30+" in both the hero and the Multi-Tenant feature.
- **Quantified the onboarding win:** "a fraction of the time" → "about four weeks of work" down to "live in an hour," plus "30 partners onboarded" as a result.
- **Added a benefit line** to the White-Label Branding feature ("Partners get the credit; NEF skips the rebuild") to match the rhythm of the Multi-Tenant line.
- **Grammar:** replaced two semicolons that misjoined an independent clause to a fragment with an em dash and a colon.
- **Trimmed** "room to grow into more" → "room to grow."

All numbers (30+ sites, 4 weeks → 1 hour, 30 partners) were supplied by the site owner.

## How to test

1. `bun dev`
2. Visit `/case-studies/energy-safe-kids`
3. Confirm hero, Project Highlights, and the three detail sections render with the updated copy.

## Note

A one-line NEF testimonial was intentionally deferred — the `CaseStudy` data model has no quote field yet, so adding one is a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined "Energy Safe Kids" case study with updated multi-tenant architecture details and clarified onboarding timelines for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/michaelbonner/bootpack-digital/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->