### PR TITLE
Fix svelte-check type errors

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -10,6 +10,10 @@ declare namespace App {
 	// interface Stuff {}
 }
 
+// Fontsource packages export only CSS (no type declarations), so TS can't
+// resolve the side-effect import on its own.
+declare module '@fontsource-variable/figtree';
+
 interface Window {
 	turnstile?: {
 		reset: (widgetId?: string) => void;

--- a/src/components/breadcrumbs.svelte
+++ b/src/components/breadcrumbs.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { resolve } from "$app/paths";
+  import { resolveRoute } from "$lib/resolve-route";
   import type { RouteId } from "$app/types";
 
   interface BreadcrumbItem {
@@ -41,7 +42,7 @@
           </svg>
           {#if item.href}
             <a
-              href={resolve(item.href)}
+              href={resolveRoute(item.href)}
               class="ml-2 text-sm font-medium text-gray-500 hover:text-gray-700"
             >
               {item.label}

--- a/src/components/fictive-redirect-modal.svelte
+++ b/src/components/fictive-redirect-modal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { replaceState } from "$app/navigation";
   import { resolve } from "$app/paths";
-  import type { RouteId } from "$app/types";
   import { onMount } from "svelte";
   import { fade, fly } from "svelte/transition";
 
@@ -16,7 +15,11 @@
 
   const closeModal = () => {
     isVisible = false;
-    replaceState(resolve(window.location.pathname as RouteId), {});
+    // `resolve()` distributes its argument across the RouteId union, so a
+    // dynamic route id isn't assignable to any single overload; narrow to a
+    // param-free route so the literal `resolve()` call still satisfies the
+    // svelte/no-navigation-without-resolve lint rule.
+    replaceState(resolve(window.location.pathname as "/"), {});
   };
 </script>
 

--- a/src/components/footer.svelte
+++ b/src/components/footer.svelte
@@ -4,7 +4,7 @@
   import clsx from "clsx";
   import { onMount } from "svelte";
   import SocialIcons from "./social-icons.svelte";
-  import { resolve } from "$app/paths";
+  import { resolveRoute } from "$lib/resolve-route";
   import type { RouteId } from "$app/types";
 
   // if this element has been in view add bpd-inView to the footer element
@@ -51,7 +51,7 @@
               "block py-4 font-semibold decoration-2 underline-offset-4 hover:underline hover:decoration-blue-300 lg:px-4 lg:py-2",
               page.url.pathname === link.url && "underline decoration-blue-600",
             )}
-            href={resolve(link.url)}>{link.label}</a
+            href={resolveRoute(link.url)}>{link.label}</a
           >
         {/each}
       </div>

--- a/src/components/header.svelte
+++ b/src/components/header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { resolve } from "$app/paths";
+  import { resolveRoute } from "$lib/resolve-route";
   import { page } from "$app/state";
   import BootpackHorizontal from "../images/bootpack-horizontal.svg";
   import MobileNav from "./mobile-nav.svelte";
@@ -28,7 +29,7 @@
               page.url.pathname === link.url &&
               "underline decoration-blue-200 hover:decoration-blue-400"
             }`}
-            href={resolve(link.url)}
+            href={resolveRoute(link.url)}
           >
             {link.label}
           </a>

--- a/src/components/mobile-nav.svelte
+++ b/src/components/mobile-nav.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { beforeNavigate } from "$app/navigation";
   import { resolve } from "$app/paths";
+  import { resolveRoute } from "$lib/resolve-route";
   import { page } from "$app/state";
   import { fade } from "svelte/transition";
   import BootpackDigital from "../images/bootpack-digital.svg";
@@ -79,7 +80,7 @@
         class={`block text-navy-500 font-semibold text-xl py-2 px-4 rounded-lg ${
           page.url.pathname === link.url && "bg-navy-100"
         }`}
-        href={resolve(link.url)}
+        href={resolveRoute(link.url)}
       >
         {link.label}
       </a>

--- a/src/lib/resolve-route.ts
+++ b/src/lib/resolve-route.ts
@@ -1,0 +1,13 @@
+import { resolve } from '$app/paths';
+import type { RouteId } from '$app/types';
+
+/**
+ * `resolve()` distributes its argument tuple across the `RouteId` union, so a
+ * value typed as the whole union (e.g. a route id read from nav data at
+ * runtime) isn't assignable to any single overload, even though every member
+ * is individually valid. All routes resolved this way are param-free, so we
+ * narrow to that overload to satisfy the type checker.
+ */
+export function resolveRoute(route: RouteId): string {
+	return resolve(route as '/');
+}


### PR DESCRIPTION
`bun run check` reported 6 errors on `master`; this clears all of them. `bun run check` and `bun run lint` both pass clean afterward.

## Root causes

1. **5 `resolve()` errors** (header, footer, mobile-nav, breadcrumbs, fictive-redirect-modal) — `resolve()` distributes its argument tuple across the `RouteId` union, so a value typed as the whole union (a route id read from nav data or `window.location.pathname` at runtime) isn't assignable to any single overload, even though every member is individually valid. Passing string literals works; passing a variable doesn't.
2. **1 fontsource error** — `@fontsource-variable/figtree` ships only CSS, with its `exports` map pointing `.` at a `.css` file and no type declaration, so TS couldn't type the side-effect import.

## Changes

- Add `src/lib/resolve-route.ts` with a `resolveRoute(route: RouteId)` helper that narrows to the param-free overload. Wired into the `href=` calls in header, footer, mobile-nav, and breadcrumbs.
- For the `replaceState()` call in fictive-redirect-modal, keep a literal `resolve()` (the `svelte/no-navigation-without-resolve` lint rule requires it) and narrow the argument inline instead.
- Declare the `@fontsource-variable/figtree` module in `src/app.d.ts`.

## Verification

- `bun run check` → 0 errors (was 6)
- `bun run lint` → passes