### PR TITLE
Make featured work item full width

### DIFF
--- a/src/components/work-item.svelte
+++ b/src/components/work-item.svelte
@@ -29,7 +29,7 @@
   class={clsx(
     "group border-t border-blue-200 pt-5",
     featured &&
-      "mx-auto w-full overflow-hidden border-0 bg-navy-800 pt-0 md:col-span-2 lg:grid lg:max-w-[1040px] lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)] xl:col-span-3",
+      "w-full overflow-hidden border-0 bg-navy-800 pt-0 md:col-span-2 lg:grid lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)] xl:col-span-3",
   )}
 >
   <a
@@ -51,7 +51,7 @@
       fetchpriority={featured ? "high" : "auto"}
       loading={featured ? "eager" : lazy ? "lazy" : "eager"}
       sizes={featured
-        ? "(min-width: 1024px) min(600px, calc(57.5vw - 37px)), calc(100vw - 32px)"
+        ? "(min-width: 1024px) min(700px, calc(57.5vw - 37px)), calc(100vw - 32px)"
         : "(min-width: 1440px) 432px, (min-width: 1280px) calc(33.333vw - 48px), (min-width: 1024px) calc(50vw - 48px), (min-width: 768px) calc(50vw - 40px), calc(100vw - 32px)"}
       src={poster}
     />

--- a/src/components/work-item.svelte
+++ b/src/components/work-item.svelte
@@ -51,7 +51,7 @@
       fetchpriority={featured ? "high" : "auto"}
       loading={featured ? "eager" : lazy ? "lazy" : "eager"}
       sizes={featured
-        ? "(min-width: 1024px) min(700px, calc(57.5vw - 37px)), calc(100vw - 32px)"
+        ? "(min-width: 1024px) min(736px, calc(57.5vw - 37px)), calc(100vw - 32px)"
         : "(min-width: 1440px) 432px, (min-width: 1280px) calc(33.333vw - 48px), (min-width: 1024px) calc(50vw - 48px), (min-width: 768px) calc(50vw - 40px), calc(100vw - 32px)"}
       src={poster}
     />


### PR DESCRIPTION
The featured work item (Primary Children's Hospital | Here Kids Win) on `/work` was capped at `lg:max-w-[1040px]`, so it rendered narrower than the surrounding `max-w-7xl` wrapper and the rest of the grid.

## Changes

- Drop `lg:max-w-[1040px]` and the now-redundant `mx-auto` from the featured `<article>` in `src/components/work-item.svelte` so it fills the full grid width.
- Raise the featured image `sizes` cap from `600px` to `700px` to match the wider left column (57.5% of the 1216px content width ≈ 699px).

Only the featured variant is affected; non-featured work items are unchanged.

https://claude.ai/code/session_01Y3qZTdCXVaNyM4f7E1D5PL