### PR TITLE
Refine blog and case study copy

### DIFF
--- a/src/lib/data/blog-posts.ts
+++ b/src/lib/data/blog-posts.ts
@@ -18,7 +18,7 @@ export const blogPosts: BlogPost[] = [
 		title: 'Introducing Office Lunch App',
 		slug: 'introducing-officelunch',
 		description:
-			'Office Lunch App is a new Bootpack Digital product that takes the daily back-and-forth out of group lunch ordering with voting, opt-ins, restaurant management, and an API for automation.',
+			'Office Lunch App replaces lunch-day chat threads with one place to opt in, vote on restaurants, save orders, and automate recurring choices.',
 		date: 'May 2, 2026',
 		thumbnail: officeLunchThumbnail
 	},
@@ -26,7 +26,7 @@ export const blogPosts: BlogPost[] = [
 		title: 'Introducing JobListing.app',
 		slug: 'introducing-joblisting',
 		description:
-			'JobListing is a new Bootpack Digital product for creating branded job pages, collecting applications, and managing candidates without a bloated ATS.',
+			'JobListing gives growing teams a branded careers page and a focused way to collect applications, manage candidates, and schedule interviews.',
 		date: 'March 25, 2026',
 		thumbnail: jobListingThumbnail
 	},
@@ -34,7 +34,7 @@ export const blogPosts: BlogPost[] = [
 		title: 'Introducing EasyCustomerFeedback',
 		slug: 'introducing-easy-customer-feedback',
 		description:
-			'EasyCustomerFeedback is a new service from Bootpack Digital that makes it simple to collect, organize, and act on feedback from your customers.',
+			'EasyCustomerFeedback puts an embeddable feedback form, a shared inbox, and integrations with Linear, GitHub Issues, and Basecamp in one service.',
 		date: 'March 9, 2026',
 		thumbnail: ecfThumbnail
 	},
@@ -42,7 +42,7 @@ export const blogPosts: BlogPost[] = [
 		title: 'Rapid product iteration with AI',
 		slug: 'ai-product-iteration',
 		description:
-			'How we use AI to build interactive prototypes, deploy them to sandboxes for testing, and leverage years of experience to help clients explore new opportunities.',
+			'How we build working prototypes in isolated sandboxes so clients can test an idea and learn from it before committing to a full build.',
 		date: 'February 6, 2026',
 		thumbnail: aiThumbnail
 	},
@@ -50,7 +50,7 @@ export const blogPosts: BlogPost[] = [
 		title: 'How we work with you on projects',
 		slug: 'how-we-work-with-you',
 		description:
-			'Learn about our onboarding process, how we collaborate in Basecamp, and our offline-first approach to problem solving.',
+			'How we start projects, keep decisions in Basecamp, use focused weekly calls, and solve problems in writing before scheduling another meeting.',
 		date: 'February 4, 2026',
 		thumbnail: howWeWorkThumbnail
 	}

--- a/src/lib/data/case-studies.ts
+++ b/src/lib/data/case-studies.ts
@@ -54,45 +54,45 @@ export const caseStudies: CaseStudy[] = [
 		slug: 'energy-safe-kids',
 		title: 'Energy Safe Kids',
 		description:
-			'We built a single platform for the National Energy Foundation that lets one team manage 30+ branded educational sites for utility partners, without the copy-paste nightmare.',
+			'We built one platform that lets the National Energy Foundation manage more than 30 educational sites for utility partners without maintaining each site separately.',
 		image: EnergySafeKidsHome,
 		link: 'https://energysafekids.org',
 		features: [
 			{
-				title: 'One Platform, Many Sites',
+				title: 'One platform, more than 30 sites',
 				description:
-					'All 30+ sites run on one shared system. When NEF pushes an update, every partner site gets it instantly. No deployment marathons required.',
+					'Every partner site runs on the same system. NEF can publish an update across the network or send it only to selected regions.',
 				icon: 'lightning' // Using lightning as a metaphor for power/energy
 			},
 			{
-				title: 'White-Label Branding',
+				title: 'A distinct brand for every partner',
 				description:
-					'Each utility partner gets a site that looks and feels like their own, right down to brand colors, logos, and regional content. Partners get the credit; NEF skips the rebuild.',
+					'Each utility partner has its own colors, logo, and regional content. NEF can launch a new branded site without rebuilding the platform.',
 				icon: 'users'
 			}
 		],
 		sections: [
 			{
-				title: 'One CMS to Rule Them All',
+				title: 'Publish once, update many sites',
 				content: [
-					'The National Energy Foundation (NEF) works with utility companies across the country to teach kids about energy safety. The problem? Every partner needed their own site, and NEF was drowning in duplicate content and one-off updates.',
-					'We built them a centralized CMS where they publish safety resources, lesson plans, and games once, then push that content to every partner site, or just specific regions. What used to take hours of copy-pasting now takes a single click.'
+					'The National Energy Foundation (NEF) works with utility companies across the country to teach children about energy safety. Each partner needed its own site, which left NEF maintaining duplicate content and repeating the same updates.',
+					'We built a central content management system for safety resources, lesson plans, and games. NEF can publish an item to every partner site or select specific regions, replacing hours of copying and pasting with one update.'
 				],
 				images: [EnergySafeKidsAbout, EnergySafeKidsTeachers]
 			},
 			{
-				title: 'Same Platform, Different Brand',
+				title: 'One system, distinct partner brands',
 				content: [
-					"Here's the cool part: even though everything runs on one platform, each partner's site feels completely custom. Rocky Mountain Power visitors see RMP branding, colors, and local info. Pacific Power visitors get theirs. It all happens automatically.",
-					"Adding a new utility partner used to mean building a whole new site, about four weeks of work. Now it's closer to flipping a switch: upload their logo, set their colors, and they're live in an hour. That's how NEF has onboarded 30 partners."
+					"A shared platform does not require a shared look. Rocky Mountain Power visitors see that utility's logo, colors, and local information. Pacific Power visitors see its brand and content, all from the same system.",
+					'A new utility partner once required about four weeks of development. Now NEF can upload a logo, choose the brand colors, and launch the site in about an hour. The organization has used that process to onboard 30 partners.'
 				],
 				images: [RockyMountainPowerHome, RockyMountainPowerAbout]
 			},
 			{
-				title: 'Growing Up: Energy Safe Leaders',
+				title: 'Reaching high school students',
 				content: [
-					"The original platform was built for younger kids, but NEF wanted to reach high schoolers too. Rather than start from scratch, we built 'Energy Safe Leaders' on top of the same tech stack.",
-					"It's a more mature look and feel with age-appropriate content, but under the hood it shares the same CMS and infrastructure. One platform, two audiences, and room to grow."
+					'NEF also wanted to reach high school students. We built Energy Safe Leaders on the existing platform instead of creating and maintaining another system.',
+					'The program has its own age-appropriate content and visual design, while sharing the same content management system and infrastructure as Energy Safe Kids. NEF can serve both audiences without duplicating the work behind the sites.'
 				],
 				images: [EnergySafeLeadersHome, EnergySafeLeadersStudentResources]
 			}
@@ -102,37 +102,37 @@ export const caseStudies: CaseStudy[] = [
 		slug: 'wasatch-fabrication',
 		title: 'Wasatch Fabrication',
 		description:
-			'Idea to launch in under six weeks. We built Wasatch Fabrication a custom platform that handles quoting, invoicing, payments, and customer communication, all in one place.',
+			"In under six weeks, we turned Wasatch Fabrication's idea into a custom platform for quotes, invoices, payments, job updates, and customer communication.",
 		image: WasatchFabrication,
 		link: 'https://wasatchfabrication.com',
 		features: [
 			{
-				title: 'Rapid Development',
+				title: 'Launched in under six weeks',
 				description:
-					'Six weeks from first conversation to production. Database, API, admin portal, customer portal, payments. The whole thing.',
+					'We designed and shipped the database, API, marketing site, admin portal, customer dashboard, and payment flow in under six weeks.',
 				icon: 'lightning'
 			},
 			{
-				title: 'Admin & Customer Portals',
+				title: 'One workflow for staff and customers',
 				description:
-					'Admins manage quotes, invoices, and payments. Customers track their jobs and pay online. No more email chains.',
+					'Staff manage quotes, invoices, and payments while customers request quotes, track jobs, share files, and pay online.',
 				icon: 'users'
 			}
 		],
 		sections: [
 			{
-				title: 'Six Weeks, Start to Finish',
+				title: 'From first conversation to launch in under six weeks',
 				content: [
-					'Wasatch Fabrication had orders coming in and no system to manage them. They needed something fast, but "fast" usually means cutting corners. We took a different approach: focus on the features that matter most, ship daily, and iterate based on real feedback.',
-					'In under six weeks we delivered the full stack: database design, API, a marketing site, an admin portal, and a customer-facing dashboard. It was tight, but the daily feedback loop kept us building the right things instead of guessing.'
+					'Wasatch Fabrication had orders coming in but no central system to manage them. The team needed software quickly, so we focused on the essential workflow, shipped updates daily, and used their feedback to decide what to build next.',
+					'In under six weeks, we delivered the database, API, marketing site, admin portal, customer dashboard, and payment flow. Daily feedback kept the scope grounded in the work Wasatch Fabrication was already doing.'
 				],
 				images: [MarketingHome, MarketingService]
 			},
 			{
-				title: 'A Dashboard Customers Actually Use',
+				title: 'A clear view for every customer',
 				content: [
-					'Before the portal, everything ran through email. Quote requests, status updates, file sharing, invoices. It worked, but things got lost. We built a customer dashboard where clients can submit quote requests, upload files, and track their jobs from start to finish.',
-					'Customers can see exactly where their order stands, view and pay invoices online through Stripe, and pull up their full history. It cut way down on "hey, what\'s the status of my order?" emails.'
+					'Before the portal, quote requests, status updates, files, and invoices all moved through email. Details were easy to lose. We built a customer dashboard where clients can request quotes, upload files, and follow each job from start to finish.',
+					"Customers can check an order's status, review past work, and pay invoices through Stripe. They no longer need to email the team whenever they want an update."
 				],
 				images: [
 					DashboardHome,
@@ -143,10 +143,10 @@ export const caseStudies: CaseStudy[] = [
 				]
 			},
 			{
-				title: 'The Admin Side',
+				title: 'An admin portal built around the real workflow',
 				content: [
-					'The admin portal is where the real work happens. We built it around how the team actually works: a quote comes in, gets reviewed, priced out with line items, and sent as an invoice. When the customer pays, production kicks off.',
-					'Admins can generate invoices, collect payments through Stripe, and keep all communication tied to specific jobs. Nothing falls through the cracks because everything lives in one place instead of scattered across inboxes.'
+					"We shaped the admin portal around Wasatch Fabrication's workflow. The team reviews each quote request, adds line-item pricing, sends the invoice, and starts production after payment.",
+					'Staff can generate invoices, collect payments through Stripe, and keep messages and files attached to the right job. The full record stays in one place instead of being split across inboxes.'
 				],
 				images: [AdminDashboard, AdminQuote]
 			}
@@ -161,7 +161,7 @@ export const caseStudies: CaseStudy[] = [
 			href: '/blog/ai-product-iteration',
 			title: 'Rapid product iteration with AI',
 			description:
-				'How we use AI to build interactive prototypes, deploy them to sandboxes for testing, and leverage years of experience to help clients explore new opportunities.'
+				'How we build working prototypes in isolated sandboxes so clients can test an idea and learn from it before committing to a full build.'
 		}
 	}
 ];

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -11,7 +11,7 @@
 
 <Seo
 	title="Blog | Bootpack Digital"
-	description="Bootpack Digital’s latest blog posts on web development, product strategy, and digital experiences for modern applications."
+	description="Practical notes from Bootpack Digital on building products, testing ideas, and running client projects."
 	canonical="/blog"
 	ogImage="/og-blog.jpg"
 	ogImageAlt="The Bootpack Blog"
@@ -21,11 +21,11 @@
 	<div class="lg:text-center">
 		<p class="text-base font-semibold tracking-wide uppercase text-blue-600">Blog</p>
 		<h1 class="mt-2 text-3xl font-extrabold leading-8 tracking-tight text-navy-900 sm:text-4xl">
-			Latest thoughts & updates
+			Notes from the work
 		</h1>
 		<p class="mt-4 mx-auto max-w-2xl text-lg text-gray-500">
-			Notes on product strategy, web development, and how we build practical digital experiences
-			with our clients.
+			What we are building, how we test product ideas, and the habits that keep client projects
+			moving.
 		</p>
 	</div>
 

--- a/src/routes/blog/ai-product-iteration/+page.svelte
+++ b/src/routes/blog/ai-product-iteration/+page.svelte
@@ -13,7 +13,7 @@
 			datePublished,
 			dateModified: datePublished,
 			description:
-				'How we use AI to build interactive prototypes, deploy them to sandboxes for testing, and leverage years of product development experience to help clients explore new opportunities.',
+				'How we build working prototypes in isolated sandboxes so clients can test an idea and learn from it before committing to a full build.',
 			mainEntityOfPage: {
 				'@type': 'WebPage',
 				'@id': 'https://bootpackdigital.com/blog/ai-product-iteration'
@@ -55,7 +55,7 @@
 
 <Seo
 	title="Rapid product iteration with AI | Bootpack Digital"
-	description="How we use AI to build interactive prototypes, deploy them to sandboxes for testing, and leverage years of product development experience to help clients explore new opportunities."
+	description="How we build working prototypes in isolated sandboxes so clients can test an idea and learn from it before committing to a full build."
 	canonical="/blog/ai-product-iteration"
 	ogType="article"
 	ogImage="/og-blog-ai-product-iteration.jpg"
@@ -82,78 +82,74 @@
 		</div>
 		<enhanced:img src={thumbnail} alt="Rapid product iteration with AI" class="mt-8 w-full rounded-lg" />
 		<p class="mt-8 text-xl leading-8 text-gray-500">
-			Building software used to mean months of planning before anyone could touch the thing. AI has
-			changed that. We use it to get working prototypes in front of clients in days instead of
-			weeks, so we can figure out what actually works before committing to a full build.
+			A specification can tell you what software should do. A working prototype shows you where the
+			idea holds up and where it falls apart. We use AI to put those prototypes in front of clients
+			in days, so we can learn before committing to a full build.
 		</p>
 	</div>
 	<div class="px-4 mx-auto mt-12 prose prose-lg text-gray-500 prose-blue">
-		<h2>You can experiment with it, not just look at it</h2>
+		<h2>Test the idea by using it</h2>
 		<p>
-			Wireframes and mockups are good for getting the general idea across, but they leave too many
-			questions unanswered. You can't really tell if a flow makes sense until you're clicking
-			through it, filling out the forms, and watching data move between screens.
+			Wireframes and mockups communicate the general idea, but they leave important questions
+			unanswered. You cannot tell whether a flow makes sense until you click through it, fill out the
+			forms, and watch data move between screens.
 		</p>
 		<p>
-			AI lets us build working prototypes fast. Not pixel-perfect screenshots, actual applications
-			you can use. Your team logs in, tries things out, and gives feedback based on the real
-			experience. That's a fundamentally different conversation than pointing at a static design and
-			saying "yeah, I think that'll work."
+			AI helps us build working prototypes quickly. Your team can log in, complete a task, and give
+			feedback based on what happened. That produces a better conversation than pointing at a static
+			design and saying, "Yeah, I think that'll work."
 		</p>
 		<p>
-			The feedback gets better too. "This form is confusing" is something you can act on. "I'm not
-			sure about the UX" isn't. When people can touch the product early, you skip the guessing and
-			get straight to the useful stuff.
+			The feedback gets more useful too. "This form is confusing" gives us a problem to solve. "I'm
+			not sure about the UX" does not. Letting people use the product early replaces guesswork with
+			specific observations.
 		</p>
 
 		<h2>Test without touching production</h2>
 		<p>
-			The obvious concern with moving fast: what if we break something? Fair question. That's why
+			Moving fast raises an obvious concern. What if we break something? That is why
 			every prototype and experiment gets its own sandbox, completely separate from your production
 			environment.
 		</p>
 		<p>
-			These aren't demos running on someone's laptop. They're real deployments your team can access
+			These are not demos running on someone's laptop. They are deployments your team can access
 			from any device, share with stakeholders, and test on their own time. If the idea works, we
 			know how to move it into production. If it doesn't, we shut it down and move on. No risk to
 			what's already live.
 		</p>
 		<p>
-			That safety net changes how you think about experimentation. You can try something ambitious
-			knowing the downside is "we learned something," not "we took down the site."
+			That separation makes ambitious experiments practical. A failed test teaches us what to change
+			without taking down the live product.
 		</p>
 
-		<h2>Fast doesn't necessarily mean sloppy</h2>
+		<h2>Speed still needs judgment</h2>
 		<p>
-			There's a default assumption that speed and quality are at odds with each other. That feels
-			like a false dichotomy to us. AI handles the repetitive, boilerplate stuff so we can focus our
-			time where it counts: architecture decisions, edge cases, user experience, and making sure the
-			code is maintainable.
+			Moving quickly does not excuse careless work. AI handles repetitive setup, leaving us more time
+			for architecture, edge cases, user experience, and maintainable code.
 		</p>
 		<p>
-			We've been doing this long enough to know what happens when you cut corners to move fast. Our
-			prototypes are built on solid foundations from day one, so when something graduates from
-			sandbox to production, you're not looking at a rewrite.
+			We also know what rushed shortcuts cost later. We make the same deliberate technical choices in
+			a prototype that we would in production, so a successful test can become the start of the real
+			product instead of a disposable demo.
 		</p>
 
-		<h2>AI is a rapid iteration tool, driven by our experience</h2>
+		<h2>The tool is fast. The decisions still matter.</h2>
 		<p>
-			AI can generate code quickly, but it doesn't know which feature to prototype first, how to
-			structure a test so you actually learn something, or when to stop iterating and commit to a
-			direction. That takes judgment, and judgment comes from building and maintaining successful
-			products.
+			AI can generate code quickly, but it does not know which feature to prototype first, how to
+			structure a useful test, or when to stop iterating and commit to a direction. Those choices
+			require product and engineering judgment.
 		</p>
 		<p>
-			We've worked across industries and project types. We've seen what works and what doesn't. When
-			we help you iterate on an idea, we're not just writing code; we're applying everything we've
-			learned about what makes products succeed to help you make better calls, faster.
+			Our job is to decide what to test, keep the test focused, and interpret what your team learns
+			from it. The code matters, but those decisions determine whether a prototype answers the right
+			question.
 		</p>
 
-		<h2>Try it and see</h2>
+		<h2>Put the idea to work</h2>
 		<p>
-			Whether you're testing a new feature, validating a startup concept, or exploring a new market,
-			the math changes when you can go from idea to working prototype in days. Less time debating in
-			the abstract, more time learning from real usage.
+			Whether you are testing a feature, validating a startup concept, or exploring a market, a
+			working prototype gives the discussion something concrete. You spend less time debating what
+			might work and more time learning from people using it.
 		</p>
 		<p>If you've got an idea you want to explore, let's build something and find out.</p>
 	</div>
@@ -168,8 +164,8 @@
 		>
 			<p class="text-xl font-semibold text-gray-900">How we work with you on projects</p>
 			<p class="mt-3 text-base text-gray-500">
-				Learn about our onboarding process, how we collaborate in Basecamp, and our offline-first
-				approach to problem solving.
+				How we start projects, keep decisions in Basecamp, and solve problems in writing before
+				scheduling another meeting.
 			</p>
 		</a>
 	</div>

--- a/src/routes/blog/how-we-work-with-you/+page.svelte
+++ b/src/routes/blog/how-we-work-with-you/+page.svelte
@@ -13,7 +13,7 @@
 			datePublished,
 			dateModified: datePublished,
 			description:
-				'A look at how we run projects at Bootpack Digital: onboarding, Basecamp collaboration, weekly check-ins, and our writing-first approach to problem solving.',
+				'How we start projects, keep decisions in Basecamp, use focused weekly calls, and solve problems in writing before scheduling another meeting.',
 			mainEntityOfPage: {
 				'@type': 'WebPage',
 				'@id': 'https://bootpackdigital.com/blog/how-we-work-with-you'
@@ -55,7 +55,7 @@
 
 <Seo
 	title="How we work with you on projects | Bootpack Digital"
-	description="A look at how we run projects at Bootpack Digital: onboarding, Basecamp collaboration, weekly check-ins, and our writing-first approach to problem solving."
+	description="How we start projects, keep decisions in Basecamp, use focused weekly calls, and solve problems in writing before scheduling another meeting."
 	canonical="/blog/how-we-work-with-you"
 	ogType="article"
 	ogImage="/og-blog-how-we-work-with-you.jpg"
@@ -82,57 +82,55 @@
 		</div>
 		<enhanced:img src={thumbnail} alt="How we work with you on projects" class="mt-8 w-full rounded-lg" />
 		<p class="mt-8 text-xl leading-8 text-gray-500">
-			We've tried a lot of ways to run projects over the years. What we've settled on comes down to
-			a few things: keep everyone in the loop, write things down, and don't waste people's time.
-			Here's how it works in practice.
+			Good project communication should make the work easier, not become another job to manage. We
+			keep decisions visible, write down the details, and schedule a meeting only when a live
+			conversation will help.
 		</p>
 	</div>
 	<div class="px-4 mx-auto mt-12 prose prose-lg text-gray-500 prose-blue">
 		<h2>Getting started</h2>
 		<p>
-			Before we write any code, we spend time understanding what you're actually trying to
-			accomplish. Not just "build a website" or "make an app," but the business problem behind it.
-			Who are your users? What does success look like? What's been tried before? This upfront
-			conversation saves us from building the wrong thing.
+			Before we write code, we spend time understanding what you are trying to accomplish. "Build a
+			website" or "make an app" describes the output. We need to understand the business problem
+			behind it.
+			Who are your users? What does success look like? What has been tried before? Answering those
+			questions helps us define the right project before development begins.
 		</p>
 
 		<h2>Everything lives in Basecamp</h2>
 		<p>
 			We use <a href="https://basecamp.com/learn" target="_blank" rel="noopener noreferrer"
 				>Basecamp</a
-			> for all project communication. Everyone on the project gets access: your team, our team,
-			whoever needs to be in the loop. Files, discussions, to-do lists, updates. It's all in one
-			place.
+			> for project communication. Everyone who needs the context gets access. Basecamp holds the
+			files, discussions, to-do lists, decisions, and progress updates in one place.
 		</p>
 		<p>
-			The big win here is no more digging through email threads to find that one decision from three
-			weeks ago. If it happened on the project, it's in Basecamp. You can check in anytime and see
-			exactly where things stand.
+			You do not have to dig through email for a decision from three weeks ago. If it affects the
+			project, it goes in Basecamp, where anyone can check the current status and the record behind
+			it.
 		</p>
 
 		<h2>Weekly check-ins (when they make sense)</h2>
 		<p>
-			For bigger projects, we'll hop on a weekly call to show what we've built, talk through what's
-			coming up, and make decisions together. We keep these focused and try not to let them run long.
+			For larger projects, we use a weekly call to demonstrate the work, discuss what is next, and
+			make decisions together. We keep the agenda focused and the call short.
 			For smaller projects, we skip them and handle everything asynchronously in Basecamp.
 		</p>
 		<p>
 			We record every call. If someone can't make it, they can watch it later. We also post a
 			summary in Basecamp with the key decisions and action items, so nobody has to scrub through a
-			30-minute video for the one thing they need.
+			30-minute recording for one decision.
 		</p>
 
 		<h2>Writing first, meetings second</h2>
 		<p>
-			When a tricky problem comes up, our first instinct isn't to jump on a call. We write it up.
-			What's the problem, what are the options, what do we recommend. This gives everyone time to
-			think it through instead of making snap decisions in a meeting.
+			When a tricky problem comes up, we write it down before scheduling a call. We explain the
+			problem, lay out the options, and make a recommendation. Everyone gets time to consider the
+			tradeoffs instead of making a snap decision in a meeting.
 		</p>
 		<p>
-			It also means our developers get long, uninterrupted stretches to focus on the work. Fewer
-			context switches, better code. When we do need to talk something through live, the
-			conversation is better because everyone's already read the write-up and had time to form an
-			opinion.
+			Writing first also gives our developers longer blocks of uninterrupted work. When a live
+			conversation is necessary, everyone arrives with the same context and time to form an opinion.
 		</p>
 	</div>
 </div>
@@ -146,15 +144,15 @@
 		>
 			<p class="text-xl font-semibold text-gray-900">Rapid product iteration with AI</p>
 			<p class="mt-3 text-base text-gray-500">
-				How we use AI to build interactive prototypes, deploy them to sandboxes for testing, and
-				leverage years of experience to help clients explore new opportunities.
+				How we build working prototypes in isolated sandboxes so clients can test an idea before
+				committing to a full build.
 			</p>
 		</a>
 	</div>
 </div>
 
 <ContactBanner
-	textLine1="Ready to get started?"
-	textLine2="Send us a message so we can chat."
+	textLine1="Have a project that needs a clear plan?"
+	textLine2="Tell us what you're trying to accomplish."
 	bgColor="bg-gray-50"
 />

--- a/src/routes/blog/introducing-easy-customer-feedback/+page.svelte
+++ b/src/routes/blog/introducing-easy-customer-feedback/+page.svelte
@@ -23,7 +23,7 @@
 			datePublished,
 			dateModified: datePublished,
 			description:
-				'EasyCustomerFeedback is a new service from Bootpack Digital that makes it simple to collect, organize, and act on feedback from your customers.',
+				'EasyCustomerFeedback puts an embeddable feedback form, a shared inbox, and integrations with Linear, GitHub Issues, and Basecamp in one service.',
 			mainEntityOfPage: {
 				'@type': 'WebPage',
 				'@id': 'https://bootpackdigital.com/blog/introducing-easy-customer-feedback'
@@ -65,7 +65,7 @@
 
 <Seo
 	title="Introducing EasyCustomerFeedback | Bootpack Digital"
-	description="EasyCustomerFeedback is a new service from Bootpack Digital that makes it simple to collect, organize, and act on feedback from your customers."
+	description="EasyCustomerFeedback puts an embeddable feedback form, a shared inbox, and integrations with Linear, GitHub Issues, and Basecamp in one service."
 	canonical="/blog/introducing-easy-customer-feedback"
 	ogType="article"
 	ogImage="/og-blog-introducing-easy-customer-feedback.jpg"
@@ -91,15 +91,16 @@
 			Published on <time datetime={datePublished}>March 9, 2026</time>
 		</div>
 		<p class="mt-8 text-xl leading-8 text-gray-500">
-			We work with a handful of companies that care a lot about what their customers have to say,
-			but they didn't have an easy and affordable way to collect that feedback, so we built it.
+			Customer feedback tends to arrive everywhere: email, support tickets, calls, and chat. We built
+			EasyCustomerFeedback to collect it in one place and move useful submissions into the tools
+			your team already uses.
 		</p>
 	</div>
 
 	<div class="px-4 mx-auto mt-12 prose prose-lg text-gray-500 prose-blue">
 		<p>
-			Visit <a href="https://easycustomerfeedback.com/"> easycustomerfeedback.com </a> to get started
-			now.
+			Visit <a href="https://easycustomerfeedback.com/">easycustomerfeedback.com</a> to see it in
+			action.
 		</p>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
@@ -118,7 +119,7 @@
 			</figure>
 		</div>
 
-		<h2>Custom feedback boards</h2>
+		<h2>One inbox for customer feedback</h2>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
 				<enhanced:img
@@ -143,11 +144,11 @@
 			</figure>
 		</div>
 		<p>
-			All of the submissions that come in are shown in a list. From there, you can prioritize them,
-			assign them, or sync them with a third-party ticket system.
+			Every submission appears in a shared inbox. Your team can review the details, set a priority,
+			assign an owner, and send the item to the system where the work will happen.
 		</p>
 
-		<h2>Embeddable widgets</h2>
+		<h2>Add the form to your existing site</h2>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
 				<enhanced:img
@@ -165,12 +166,12 @@
 			</figure>
 		</div>
 		<p>
-			We make it easy for you to drop the widget on your existing pages. Just copy and paste the
-			script from the dashboard. We give you some options to configure the text, the available
-			fields, and the colors.
+			Copy one script from the dashboard to add the feedback form to an existing page. You can choose
+			the fields, rewrite the prompts, and match the colors to your site without rebuilding the
+			form yourself.
 		</p>
 
-		<h2>Integrations with existing systems</h2>
+		<h2>Send accepted feedback to the right tool</h2>
 
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
@@ -188,23 +189,28 @@
 				/>
 			</figure>
 		</div>
-		<p>You can currently integrate with Linear, GitHub Issues, or Basecamp.</p>
-
-		<h2>Blazing fast</h2>
-		<p>We built it from scratch with the latest tech to be as fast as possible.</p>
-
-		<h2>Try it today and tell us what you think</h2>
 		<p>
-			We're excited for as many people as possible to use it. Give it a try and give us some
-			feedback! <a href="https://easycustomerfeedback.com/"
-				>Start collecting feedback from your customers today</a
-			>
+			Turn a submission into a Linear issue, GitHub issue, or Basecamp to-do without copying the
+			details by hand. The original feedback remains available for reference.
+		</p>
+
+		<h2>A small tool with a focused job</h2>
+		<p>
+			EasyCustomerFeedback does not try to replace your project tracker or support desk. It collects
+			feedback, helps your team sort it, and passes accepted work to the tools you already trust.
+		</p>
+
+		<h2>Collect your first submission</h2>
+		<p>
+			Create a board, customize the form, and add it to your site at
+			<a href="https://easycustomerfeedback.com/">easycustomerfeedback.com</a>. And yes, you can use
+			it to tell us what needs work.
 		</p>
 	</div>
 </div>
 
 <ContactBanner
-	textLine1="Have some web app development questions?"
-	textLine2="Send us a message so we can chat."
+	textLine1="Need a focused tool for your team's workflow?"
+	textLine2="Tell us where the current process breaks down."
 	bgColor="bg-gray-100"
 />

--- a/src/routes/blog/introducing-joblisting/+page.svelte
+++ b/src/routes/blog/introducing-joblisting/+page.svelte
@@ -24,7 +24,7 @@
 			datePublished,
 			dateModified: datePublished,
 			description:
-				'JobListing is a new Bootpack Digital product for creating branded job pages, collecting applications, and managing candidates without a bloated ATS.',
+				'JobListing gives growing teams a branded careers page and a focused way to collect applications, manage candidates, and schedule interviews.',
 			mainEntityOfPage: {
 				'@type': 'WebPage',
 				'@id': 'https://bootpackdigital.com/blog/introducing-joblisting'
@@ -66,7 +66,7 @@
 
 <Seo
 	title="Introducing JobListing.app | Bootpack Digital"
-	description="JobListing.app is a new Bootpack Digital product for creating branded job pages, collecting applications, and managing candidates without a bloated ATS."
+	description="JobListing gives growing teams a branded careers page and a focused way to collect applications, manage candidates, and schedule interviews."
 	canonical="/blog/introducing-joblisting"
 	ogType="article"
 	ogImage="/og-blog-introducing-joblisting.jpg"
@@ -93,10 +93,9 @@
 		</div>
 		<enhanced:img src={homepage} alt="JobListing homepage" class="mt-8 w-full rounded-lg" />
 		<p class="mt-8 text-xl leading-8 text-gray-500">
-			Hiring tools have a habit of getting complicated fast. You start with a simple need, post a
-			job, collect applications, move good candidates through the process, and suddenly you're
-			buried in an ATS built for a much bigger company than yours. JobListing is our answer to that
-			problem.
+			Hiring software gets complicated fast. A growing team needs to publish a job, collect
+			applications, and keep promising candidates moving. It does not need an applicant tracking
+			system designed for a multinational company. We built JobListing for that gap.
 		</p>
 	</div>
 
@@ -105,12 +104,11 @@
 			Visit <a href="https://joblisting.app/">joblisting.app</a> to see it in action.
 		</p>
 
-		<h2>A clean hiring workflow from the first click</h2>
+		<h2>A focused hiring workflow from the first click</h2>
 		<p>
-			JobListing gives employers a straightforward place to publish openings and manage hiring
-			without the usual clutter. The public-facing side is a branded job listing site your
-			candidates can apply through, and the internal side is a focused dashboard for listings,
-			applicants, interviews, and hiring activity.
+			JobListing combines a branded careers site for candidates with a private dashboard for your
+			team. You can publish openings, collect applications, review candidates, and coordinate
+			interviews without navigating unrelated enterprise features.
 		</p>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
@@ -129,10 +127,8 @@
 			</figure>
 		</div>
 		<p>
-			For small teams and growing companies, that simplicity matters. We can give clients a hosted,
-			branded careers page that looks like part of their company instead of a bolted-on third-party
-			tool. If they already have a website they want to keep applicants on, they can also use an
-			embeddable widget to place openings and applications directly on their own site.
+			Each company gets a hosted careers page that matches its brand. Teams that want to keep
+			candidates on an existing website can embed their openings and application forms there instead.
 		</p>
 
 		<h2>Create job listings and application forms that fit the role</h2>
@@ -165,17 +161,16 @@
 			</figure>
 		</div>
 		<p>
-			That means no more forcing your process into someone else's template. Need a resume upload, short
-			text answers, longer written responses, or different required fields? Build the form you need,
-			then present it inside a branded application experience or embed it into an existing website.
-			Once submissions start coming in, manage candidates in either a board or table view.
+			A role can ask for a resume, short answers, longer responses, or any required fields your team
+			needs. Publish the form on your JobListing careers page or embed it on your existing site. As
+			applications arrive, review them in a board or table view.
 		</p>
 
-		<h2>Track candidates with the context you actually need</h2>
+		<h2>Keep the full story with each candidate</h2>
 		<p>
-			A resume by itself usually isn't enough. Hiring requires notes, stage changes, interview
-			details, internal discussion, and a clear history of what happened when. JobListing keeps that
-			context on each submission so your team can move faster without losing the thread.
+			A resume rarely tells the whole story. Each application keeps its notes, rating, stage changes,
+			interview details, and activity history together, so the team does not have to reconstruct a
+			decision from email and chat.
 		</p>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
@@ -201,15 +196,14 @@
 			</figure>
 		</div>
 		<p>
-			You can review the submission, add internal notes, rate applicants, move them through stages,
-			and schedule interviews from the same place. The result is a hiring process that's easier to
-			follow for everyone involved.
+			Reviewers can see the submission, add internal notes, rate the applicant, change their stage,
+			and schedule an interview from the same screen. Everyone works from the same record.
 		</p>
 
 		<h2>Interviews and analytics built into the workflow</h2>
 		<p>
-			JobListing doesn't stop at collecting applications. It also helps you coordinate interviews
-			and understand how each job listing is performing.
+			The interview view gathers upcoming meetings and participant details in one schedule. Calendar
+			subscriptions keep that schedule available outside JobListing.
 		</p>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
@@ -228,25 +222,21 @@
 			</figure>
 		</div>
 		<p>
-			Upcoming interviews are collected in one view, with calendar subscription support and
-			participant details right there in the schedule. On the analytics side, you can see views,
-			applications, conversion rate, and where candidates are coming from, including direct traffic
-			and UTM-tagged sources.
+			Listing analytics show page views, applications, conversion rate, direct traffic, and
+			UTM-tagged sources. That makes it easier to see which recruiting channels bring in candidates
+			instead of relying on a hunch.
 		</p>
 
 		<h2>Built for teams that want less software, not more</h2>
 		<p>
-			We built JobListing for companies that need a solid hiring workflow without adopting an
-			overengineered platform. If your team wants a better-looking careers page, clearer application
-			intake, and a practical system for moving candidates forward, that's exactly what this product
-			is for.
+			JobListing is for teams that need a credible careers page and an organized hiring process, but
+			do not need the cost and complexity of an enterprise system.
 		</p>
 
 		<h2>See JobListing for yourself</h2>
 		<p>
-			If you're hiring and your current process feels messier than it should, take a look at
-			<a href="https://joblisting.app/">JobListing</a>. It gives you the essentials to publish jobs,
-			collect applications, and run a more organized hiring process from start to finish.
+			If applications are scattered across forms, email, and spreadsheets, visit
+			<a href="https://joblisting.app/">JobListing</a> to see the full workflow.
 		</p>
 	</div>
 </div>
@@ -260,8 +250,8 @@
 		>
 			<p class="text-xl font-semibold text-gray-900">Rapid product iteration with AI</p>
 			<p class="mt-3 text-base text-gray-500">
-				How we use AI to build interactive prototypes, deploy them to sandboxes for testing, and
-				leverage years of experience to help clients explore new opportunities.
+				How we build working prototypes in isolated sandboxes so clients can test an idea before
+				committing to a full build.
 			</p>
 		</a>
 	</div>

--- a/src/routes/blog/introducing-officelunch/+page.svelte
+++ b/src/routes/blog/introducing-officelunch/+page.svelte
@@ -28,7 +28,7 @@
 			datePublished,
 			dateModified: datePublished,
 			description:
-				'Office Lunch App is a new Bootpack Digital product that takes the daily back-and-forth out of group lunch ordering with voting, opt-ins, restaurant management, and an API for automation.',
+				'Office Lunch App replaces lunch-day chat threads with one place to opt in, vote on restaurants, save orders, and automate recurring choices.',
 			mainEntityOfPage: {
 				'@type': 'WebPage',
 				'@id': 'https://bootpackdigital.com/blog/introducing-officelunch'
@@ -70,7 +70,7 @@
 
 <Seo
 	title="Introducing Office Lunch App | Bootpack Digital"
-	description="Office Lunch App is a new Bootpack Digital product that takes the daily back-and-forth out of group lunch ordering with voting, opt-ins, restaurant management, and an API for automation."
+	description="Office Lunch App replaces lunch-day chat threads with one place to opt in, vote on restaurants, save orders, and automate recurring choices."
 	canonical="/blog/introducing-officelunch"
 	ogType="article"
 	ogImage="/og-blog-introducing-officelunch.jpg"
@@ -105,10 +105,9 @@
 			fetchpriority="high"
 		/>
 		<p class="mt-8 text-xl leading-8 text-gray-500">
-			Group lunch ordering is the kind of small, daily problem that quietly eats hours every week.
-			Someone has to ask who's in, chase replies, juggle a menu link in a chat thread, collect
-			orders, and remember who paid. Office Lunch App is our take on a tool that makes that whole
-			rhythm feel effortless, even when you're coordinating across multiple teams.
+			A group lunch can generate a surprising amount of admin. Someone asks who is in, chases
+			replies, finds the menu, collects orders, and remembers who paid. Office Lunch App puts that
+			work in one place, even when several teams share the account.
 		</p>
 	</div>
 
@@ -119,12 +118,10 @@
 
 		<h2>Why we built it</h2>
 		<p>
-			We're a distributed team that still loves a good shared lunch when people are in the office.
-			What kept tripping us up wasn't the food, it was the coordination: opt-ins lost in chat,
-			restaurant links pasted in twice, and the same handful of people always stuck asking
-			"who's ordering today?" Office Lunch App turns that into a calm, predictable flow. Admins set
-			up restaurants and rules once, and everyone else just opts in, votes, and saves their
-			favorite orders.
+			We are a distributed team, but we still share lunch when people are in the office. The food was
+			never the problem. Responses disappeared in chat, restaurant links were pasted twice, and the
+			same few people kept asking, "Who's ordering today?" Now admins set the restaurants and rules
+			once. Everyone else opts in, votes, and saves their usual orders.
 		</p>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
@@ -151,9 +148,9 @@
 			</figure>
 		</div>
 
-		<h2>Voting that actually picks a winner</h2>
+		<h2>Voting that ends with a decision</h2>
 		<p>
-			Most lunch decisions are not really decisions, they're long pauses in a chat. Office Lunch App
+			Most lunch decisions are long pauses in a chat. Office Lunch App
 			gives everyone a quick voting view so the group can pick a restaurant in under a minute.
 			Admins see the live results, can break ties, and lock in the winner without a follow-up
 			thread.
@@ -183,16 +180,16 @@
 			</figure>
 		</div>
 		<p>
-			Past winners are tracked too, so the same place doesn't sneak onto the list four weeks in a
+			Past winners stay in the history, so the same place does not sneak onto the list four weeks in a
 			row.
 		</p>
 
 		<h2>Restaurants and saved orders, in one place</h2>
 		<p>
-			Each organization gets a restaurant list with menu links, budget tiers, and a one-click "Make
-			Order" button. Employees can save their usual order at each restaurant so they're not
-			retyping a sandwich name three times a week. Anyone can suggest a new spot, and admins
-			review requests on a dedicated screen instead of digging through messages.
+			Each organization has a restaurant list with menu links, budget tiers, and a "Make Order"
+			button. Employees can save a usual order for each restaurant instead of retyping it every week.
+			Anyone can suggest a new place, and admins review those requests in the app instead of digging
+			through messages.
 		</p>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
@@ -241,16 +238,14 @@
 			</figure>
 		</div>
 		<p>
-			On lunch day, whoever is placing the order pulls up the order management view, sees who opted
-			in with their saved choice, and works through a single consolidated list instead of stitching
-			DMs together.
+			On lunch day, the person placing the order sees everyone who opted in and each saved choice in
+			one list. No stitching together direct messages at the last minute.
 		</p>
 
-		<h2>Built for multiple teams and orgs</h2>
+		<h2>Separate settings for each team</h2>
 		<p>
-			Office Lunch App is multi-tenant from the ground up. If you run more than one office, agency
-			client, or team, you can manage them as separate organizations, each with its own
-			restaurants, users, and settings, but with shared admin oversight where it makes sense.
+			If you manage more than one office or team, each can have its own restaurants, users, and
+			settings. Administrators can oversee several organizations without mixing up their lunch plans.
 		</p>
 		<div class="grid gap-x-5 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			<figure>
@@ -288,16 +283,15 @@
 			</figure>
 		</div>
 		<p>
-			Roles, opt-in defaults, and per-org preferences all live in settings, so each team can run
-			lunch the way they actually want to.
+			Roles, opt-in defaults, and organization preferences live in settings, so each team can set its
+			own routine.
 		</p>
 
-		<h2>Tokenized API access for automation</h2>
+		<h2>API access for recurring tasks</h2>
 		<p>
-			One thing we wanted from day one was the ability to automate opt-ins. If you're always in on
-			Tuesdays, or you want a Slack workflow to flip you in for Friday, Office Lunch App has
-			tokenized API access for exactly that. Generate a token, hit the endpoint, and your status
-			updates without anyone touching the UI.
+			We wanted to automate opt-ins from the start. If you always join on Tuesdays, or want a Slack
+			workflow to opt you in on Friday, create an API token and update your status without opening
+			the app.
 		</p>
 		<figure class="mx-auto mt-12 max-w-3xl">
 			<enhanced:img
@@ -311,13 +305,13 @@
 			/>
 		</figure>
 
-		<h2>A CLI for the terminal-inclined</h2>
+		<h2>A command-line tool for regular users and admins</h2>
 		<p>
 			On top of the API, we ship an official command-line tool, <code>olm</code>, published on npm
 			as
 			<a href="https://www.npmjs.com/package/@office-lunch/cli"><code>@office-lunch/cli</code></a>.
-			It's the fastest way to opt in, place an order, or run admin tasks without leaving your
-			terminal, and it slots cleanly into shell aliases, cron jobs, and CI workflows.
+			It lets you opt in, place an order, or run admin tasks without leaving the terminal. It also
+			works in shell aliases, cron jobs, and CI workflows.
 		</p>
 		<p>Install it globally and configure it once with an API token from your settings:</p>
 		<pre><code
@@ -343,17 +337,16 @@ olm admin suggestions approve <id> --notes "Added it!"
 olm admin lunch set <restaurant-id>`}</code
 			></pre>
 		<p>
-			Because everything runs through the same tokenized API, the CLI is also a clean building
-			block for automation. A short script in a cron job can opt your team in every Tuesday, or a
-			GitHub Action can post the day's selection to Slack. Either way, no one has to babysit the
-			UI.
+			The CLI uses the same API as the web app. A cron job can opt your team in every Tuesday, or a
+			GitHub Action can post the day's selection to Slack. No one has to open the interface to keep
+			the routine moving.
 		</p>
 
 		<h2>Less back-and-forth, more lunch</h2>
 		<p>
-			Office Lunch App is the tool we wanted ourselves: opinionated enough to remove the busywork,
-			flexible enough to fit how different teams already eat together. If your office lunch
-			coordination feels heavier than it should, give it a try at
+			Office Lunch App is the tool we wanted for our own lunches. It handles the repetitive details
+			without prescribing where or how a team eats. If lunch coordination takes more time than lunch,
+			give it a try at
 			<a href="https://officelunch.app/">officelunch.app</a>.
 		</p>
 	</div>
@@ -368,8 +361,8 @@ olm admin lunch set <restaurant-id>`}</code
 		>
 			<p class="text-xl font-semibold text-gray-900">Introducing JobListing.app</p>
 			<p class="mt-3 text-base text-gray-500">
-				A Bootpack Digital product for branded job pages, applications, and managing candidates
-				without a bloated ATS.
+				A branded careers page and a focused way to collect applications, manage candidates, and
+				schedule interviews.
 			</p>
 		</a>
 		<a
@@ -378,7 +371,8 @@ olm admin lunch set <restaurant-id>`}</code
 		>
 			<p class="text-xl font-semibold text-gray-900">Introducing EasyCustomerFeedback</p>
 			<p class="mt-3 text-base text-gray-500">
-				A simple way to collect, organize, and act on feedback from your customers.
+				An embeddable feedback form, shared inbox, and integrations with the tools your team already
+				uses.
 			</p>
 		</a>
 	</div>

--- a/src/routes/case-studies/+page.svelte
+++ b/src/routes/case-studies/+page.svelte
@@ -7,7 +7,7 @@
 
 <Seo
 	title="Case Studies | Bootpack Digital"
-	description="See how we've helped businesses like Wasatch Fabrication achieve their goals through custom software solutions."
+	description="See how we built a multi-site education platform for the National Energy Foundation and launched Wasatch Fabrication's custom operations software in under six weeks."
 	canonical="/case-studies"
 	ogImage="/og-case-studies.jpg"
 	ogImageAlt="Bootpack Digital case studies"
@@ -16,7 +16,7 @@
 		'@type': 'CollectionPage',
 		headline: 'Case Studies',
 		description:
-			"See how we've helped businesses like Wasatch Fabrication achieve their goals through custom software solutions.",
+			"See how we built a multi-site education platform for the National Energy Foundation and launched Wasatch Fabrication's custom operations software in under six weeks.",
 		mainEntity: {
 			'@type': 'ItemList',
 			itemListElement: caseStudies.map((study, i) => ({
@@ -32,7 +32,10 @@
 	<div class="mx-auto max-w-7xl">
 		<div class="prose lg:prose-lg text-gray-600">
 			<h1 class="tracking-tight text-navy-600">Case Studies</h1>
-			<p>A deep dive into some of our recent work.</p>
+			<p>
+				See how we replaced repeated content updates with one shared platform and turned an
+				operations workflow into working software in under six weeks.
+			</p>
 		</div>
 		<div class="grid gap-x-5 gap-y-10 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
 			{#each caseStudies as study}
@@ -73,7 +76,7 @@
 </div>
 
 <ContactBanner
-	textLine1="Ready to get started?"
-	textLine2="Send us a message so we can chat."
+	textLine1="Have a workflow that needs better software?"
+	textLine2="Tell us what's slowing your team down."
 	bgColor="bg-navy-100"
 />

--- a/src/routes/case-studies/[slug]/+page.svelte
+++ b/src/routes/case-studies/[slug]/+page.svelte
@@ -80,7 +80,7 @@
 		<div class="relative mt-12 lg:mt-24 lg:grid lg:grid-cols-2 lg:gap-8 lg:items-center">
 			<div class="relative">
 				<h2 class="text-2xl font-extrabold tracking-tight text-navy-900 sm:text-3xl">
-					Project Highlights
+					Project highlights
 				</h2>
 
 				<dl class="mt-10 space-y-10">
@@ -276,6 +276,6 @@
 
 <ContactBanner
 	textLine1="Have a project in mind?"
-	textLine2="Let's build something great together."
+	textLine2="Tell us what your team needs to accomplish."
 	bgColor="bg-gray-50"
 />


### PR DESCRIPTION
## Summary

- tighten the writing across all five blog posts and both case studies
- replace vague marketing language with specific product and project details
- align listing summaries, SEO descriptions, related-post copy, headings, and contact prompts

## Verification

- `bun run build`
- `bun run lint` (passes with one existing warning in `scripts/dokploy-preview.mjs`)
- formatting check for changed content files
- `bun run check` remains blocked by three existing dependency-type errors in `vite.config.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed blog posts, case studies, SEO descriptions, and structured metadata across the site.
  * Clarified messaging around product testing, project communication, feedback collection, hiring workflows, and team lunch coordination.
  * Updated product and project descriptions to highlight integrations, workflow improvements, prototypes, and delivery timelines.
  * Improved headings, related-post summaries, and contact banner messaging throughout blog and case-study pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->