### PR TITLE
Fix invalid blue-900 hex in app.css

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -12,7 +12,7 @@
 	--color-blue-600: #237aa5;
 	--color-blue-700: #17516e;
 	--color-blue-800: #123d52;
-	--color-blue-900: #0C293;
+	--color-blue-900: #0c2937;
 
 	--color-navy-100: #e6eff4;
 	--color-navy-200: #bfd7e3;


### PR DESCRIPTION
## What changed

`--color-blue-900` was `#0C293` — five hex digits. CSS accepts 3, 4, 6, or 8, so the declaration was invalid and the token never resolved to a color.

Restores it to `#0c2937`.

## Where the value comes from

The trailing `7` was dropped in c7fc9a7, when the palette moved from `tailwind.config.js` into `src/app.css`. The original in d8be1d4 was `#0C2937`:

```
+        900: `#0C2937`
```

It also matches the scale's own progression — `blue-800` (`#123d52`) stepped down by the same ratio the navy scale uses between 800 and 900 lands on `#0c2937`.

Lowercased so `prettier --check` passes. This was the only formatting failure in the repo; `bun run lint` fails on master because of it.

## Risk

None visually. `blue-900` is not referenced anywhere in the codebase — only the definition exists:

```
$ grep -rn "blue-900" src/
src/app.css:15:	--color-blue-900: #0c2937;
```

## Testing

- `bun run lint` — format check passes (previously failed on master); the one remaining warning in `scripts/dokploy-preview.mjs` is pre-existing
- `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)