### PR TITLE
Redesign the blog and case studies pages

### DIFF
--- a/src/components/content-list-card.svelte
+++ b/src/components/content-list-card.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import clsx from 'clsx';
+	import type { Picture } from 'vite-imagetools';
+	import LinkArrow from './link-arrow.svelte';
+
+	type Metadata =
+		| { kind: 'label'; text: string }
+		| { kind: 'date'; dateTime: string; text: string };
+
+	interface Props {
+		class?: string;
+		description: string;
+		href: string;
+		image: Picture;
+		linkText: string;
+		loading?: 'eager' | 'lazy';
+		metadata: Metadata;
+		sizes: string;
+		title: string;
+		titleSize?: 'default' | 'large';
+	}
+
+	let {
+		class: className,
+		description,
+		href,
+		image,
+		linkText,
+		loading,
+		metadata,
+		sizes,
+		title,
+		titleSize = 'default'
+	}: Props = $props();
+</script>
+
+<article class={clsx('pt-5 border-t border-blue-200 group', className)}>
+	<div class="overflow-hidden bg-blue-100 rounded-md">
+		<enhanced:img
+			alt={title}
+			class="object-cover w-full transition-transform duration-500 ease-out aspect-[16/10] group-hover:scale-[1.025] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
+			{loading}
+			{sizes}
+			src={image}
+		/>
+	</div>
+
+	<div class="pt-6 pb-4">
+		<p class="text-xs font-bold tracking-[0.16em] text-orange-800 uppercase">
+			{#if metadata.kind === 'date'}
+				<time datetime={metadata.dateTime}>{metadata.text}</time>
+			{:else}
+				{metadata.text}
+			{/if}
+		</p>
+		<a class="block" {href}>
+			<h3
+				class={clsx(
+					'mt-3 text-2xl font-bold tracking-tight leading-tight text-navy-800 hover:underline',
+					titleSize === 'large' && 'sm:text-3xl'
+				)}
+			>
+				{title}
+			</h3>
+			<p class="mt-4 text-base leading-7 text-gray-600">{description}</p>
+		</a>
+		<a
+			class="inline-flex gap-2 items-center mt-7 font-semibold text-blue-700 underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-800"
+			{href}
+		>
+			{linkText}
+			<LinkArrow />
+		</a>
+	</div>
+</article>

--- a/src/components/content-list-card.svelte
+++ b/src/components/content-list-card.svelte
@@ -35,25 +35,25 @@
 </script>
 
 <article class={clsx('pt-5 border-t border-blue-200 group', className)}>
-	<div class="overflow-hidden bg-blue-100 rounded-md">
-		<enhanced:img
-			alt={title}
-			class="object-cover w-full transition-transform duration-500 ease-out aspect-[16/10] group-hover:scale-[1.025] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
-			{loading}
-			{sizes}
-			src={image}
-		/>
-	</div>
+	<a class="block focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600" {href}>
+		<div class="overflow-hidden bg-blue-100 rounded-md">
+			<enhanced:img
+				alt={title}
+				class="object-cover w-full transition-transform duration-500 ease-out aspect-[16/10] group-hover:scale-[1.025] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
+				{loading}
+				{sizes}
+				src={image}
+			/>
+		</div>
 
-	<div class="pt-6 pb-4">
-		<p class="text-xs font-bold tracking-[0.16em] text-orange-800 uppercase">
-			{#if metadata.kind === 'date'}
-				<time datetime={metadata.dateTime}>{metadata.text}</time>
-			{:else}
-				{metadata.text}
-			{/if}
-		</p>
-		<a class="block" {href}>
+		<div class="pt-6 pb-4">
+			<p class="text-xs font-bold tracking-[0.16em] text-orange-800 uppercase">
+				{#if metadata.kind === 'date'}
+					<time datetime={metadata.dateTime}>{metadata.text}</time>
+				{:else}
+					{metadata.text}
+				{/if}
+			</p>
 			<h3
 				class={clsx(
 					'mt-3 text-2xl font-bold tracking-tight leading-tight text-navy-800 hover:underline',
@@ -63,13 +63,12 @@
 				{title}
 			</h3>
 			<p class="mt-4 text-base leading-7 text-gray-600">{description}</p>
-		</a>
-		<a
-			class="inline-flex gap-2 items-center mt-7 font-semibold text-blue-700 underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-800"
-			{href}
-		>
-			{linkText}
-			<LinkArrow />
-		</a>
-	</div>
+			<span
+				class="inline-flex gap-2 items-center mt-7 font-semibold text-blue-700 underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-800"
+			>
+				{linkText}
+				<LinkArrow />
+			</span>
+		</div>
+	</a>
 </article>

--- a/src/components/content-page-hero.svelte
+++ b/src/components/content-page-hero.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import clsx from 'clsx';
+	import TopoHeroBg from './topo-hero-bg.svelte';
+	import LinkArrow from './link-arrow.svelte';
+
+	interface Props {
+		class?: string;
+		description: string;
+		eyebrow: string;
+		heading: string;
+		linkHref: string;
+		linkText: string;
+	}
+
+	let {
+		class: className,
+		description,
+		eyebrow,
+		heading,
+		linkHref,
+		linkText
+	}: Props = $props();
+</script>
+
+<section class={clsx('overflow-hidden relative bg-blue-50', className)}>
+	<TopoHeroBg />
+	<div class="relative px-4 py-16 mx-auto max-w-7xl sm:px-6 md:py-24 lg:px-8 lg:py-28">
+		<div class="grid gap-8 items-end lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)] lg:gap-20">
+			<div>
+				<p class="mb-5 text-sm font-bold tracking-[0.18em] text-orange-800 uppercase">
+					{eyebrow}
+				</p>
+				<h1
+					class="max-w-4xl text-4xl font-extrabold tracking-tight leading-[1.04] text-navy-700 sm:text-5xl lg:text-6xl xl:text-7xl"
+				>
+					{heading}
+				</h1>
+			</div>
+			<div class="pb-1">
+				<p class="max-w-xl text-lg leading-8 text-navy-600">{description}</p>
+				<a
+					class="inline-flex items-center mt-6 font-semibold text-blue-700 underline decoration-blue-300 underline-offset-4 hover:text-blue-800 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600"
+					href={linkHref}
+				>
+					{linkText}
+					<LinkArrow class="ml-2" />
+				</a>
+			</div>
+		</div>
+	</div>
+</section>

--- a/src/components/link-arrow.svelte
+++ b/src/components/link-arrow.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import clsx from 'clsx';
+
+	interface Props {
+		class?: string;
+	}
+
+	let { class: className }: Props = $props();
+</script>
+
+<svg aria-hidden="true" class={clsx('size-4', className)} fill="none" viewBox="0 0 20 20">
+	<path
+		d="m7 4 6 6-6 6"
+		stroke="currentColor"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		stroke-width="2"
+	/>
+</svg>

--- a/src/lib/data/blog-posts.ts
+++ b/src/lib/data/blog-posts.ts
@@ -1,15 +1,16 @@
 import type { Picture } from 'vite-imagetools';
-import officeLunchThumbnail from '../../images/officelunch-screenshots/homepage-hero.jpg?enhanced';
-import jobListingThumbnail from '../../images/joblisting-app-screenshots/homepage.jpg?enhanced';
-import ecfThumbnail from '../../images/easycustomerfeedback-screenshots/homepage-hero.jpg?enhanced';
-import aiThumbnail from '../../images/rapid-iteration-with-ai.jpg?enhanced';
-import howWeWorkThumbnail from '../../images/how-we-work-with-you.jpg?enhanced';
+import officeLunchThumbnail from '../../images/officelunch-screenshots/homepage-hero.jpg?w=320;480;640;800;960;1200&enhanced';
+import jobListingThumbnail from '../../images/joblisting-app-screenshots/homepage.jpg?w=320;480;640;800;960;1200&enhanced';
+import ecfThumbnail from '../../images/easycustomerfeedback-screenshots/homepage-hero.jpg?w=320;480;640;800;960;1200&enhanced';
+import aiThumbnail from '../../images/rapid-iteration-with-ai.jpg?w=320;480;640;800;960;1200&enhanced';
+import howWeWorkThumbnail from '../../images/how-we-work-with-you.jpg?w=320;480;640;800;960;1200&enhanced';
 
 export type BlogPost = {
 	title: string;
 	slug: string;
 	description: string;
 	date: string;
+	isoDate: string;
 	thumbnail: Picture;
 };
 
@@ -20,6 +21,7 @@ export const blogPosts: BlogPost[] = [
 		description:
 			'Office Lunch App replaces lunch-day chat threads with one place to opt in, vote on restaurants, save orders, and automate recurring choices.',
 		date: 'May 2, 2026',
+		isoDate: '2026-05-02',
 		thumbnail: officeLunchThumbnail
 	},
 	{
@@ -28,6 +30,7 @@ export const blogPosts: BlogPost[] = [
 		description:
 			'JobListing gives growing teams a branded careers page and a focused way to collect applications, manage candidates, and schedule interviews.',
 		date: 'March 25, 2026',
+		isoDate: '2026-03-25',
 		thumbnail: jobListingThumbnail
 	},
 	{
@@ -36,6 +39,7 @@ export const blogPosts: BlogPost[] = [
 		description:
 			'EasyCustomerFeedback puts an embeddable feedback form, a shared inbox, and integrations with Linear, GitHub Issues, and Basecamp in one service.',
 		date: 'March 9, 2026',
+		isoDate: '2026-03-09',
 		thumbnail: ecfThumbnail
 	},
 	{
@@ -44,6 +48,7 @@ export const blogPosts: BlogPost[] = [
 		description:
 			'How we build working prototypes in isolated sandboxes so clients can test an idea and learn from it before committing to a full build.',
 		date: 'February 6, 2026',
+		isoDate: '2026-02-06',
 		thumbnail: aiThumbnail
 	},
 	{
@@ -52,6 +57,7 @@ export const blogPosts: BlogPost[] = [
 		description:
 			'How we start projects, keep decisions in Basecamp, use focused weekly calls, and solve problems in writing before scheduling another meeting.',
 		date: 'February 4, 2026',
+		isoDate: '2026-02-04',
 		thumbnail: howWeWorkThumbnail
 	}
 ];

--- a/src/lib/data/blog-posts.ts
+++ b/src/lib/data/blog-posts.ts
@@ -9,19 +9,27 @@ export type BlogPost = {
 	title: string;
 	slug: string;
 	description: string;
-	date: string;
-	isoDate: string;
+	publishedAt: `${number}-${number}-${number}`;
 	thumbnail: Picture;
 };
 
-export const blogPosts: BlogPost[] = [
+const blogPostDateFormatter = new Intl.DateTimeFormat('en-US', {
+	day: 'numeric',
+	month: 'long',
+	timeZone: 'UTC',
+	year: 'numeric'
+});
+
+export const formatBlogPostDate = (publishedAt: BlogPost['publishedAt']) =>
+	blogPostDateFormatter.format(new Date(`${publishedAt}T00:00:00Z`));
+
+export const blogPosts = [
 	{
 		title: 'Introducing Office Lunch App',
 		slug: 'introducing-officelunch',
 		description:
 			'Office Lunch App replaces lunch-day chat threads with one place to opt in, vote on restaurants, save orders, and automate recurring choices.',
-		date: 'May 2, 2026',
-		isoDate: '2026-05-02',
+		publishedAt: '2026-05-02',
 		thumbnail: officeLunchThumbnail
 	},
 	{
@@ -29,8 +37,7 @@ export const blogPosts: BlogPost[] = [
 		slug: 'introducing-joblisting',
 		description:
 			'JobListing gives growing teams a branded careers page and a focused way to collect applications, manage candidates, and schedule interviews.',
-		date: 'March 25, 2026',
-		isoDate: '2026-03-25',
+		publishedAt: '2026-03-25',
 		thumbnail: jobListingThumbnail
 	},
 	{
@@ -38,8 +45,7 @@ export const blogPosts: BlogPost[] = [
 		slug: 'introducing-easy-customer-feedback',
 		description:
 			'EasyCustomerFeedback puts an embeddable feedback form, a shared inbox, and integrations with Linear, GitHub Issues, and Basecamp in one service.',
-		date: 'March 9, 2026',
-		isoDate: '2026-03-09',
+		publishedAt: '2026-03-09',
 		thumbnail: ecfThumbnail
 	},
 	{
@@ -47,8 +53,7 @@ export const blogPosts: BlogPost[] = [
 		slug: 'ai-product-iteration',
 		description:
 			'How we build working prototypes in isolated sandboxes so clients can test an idea and learn from it before committing to a full build.',
-		date: 'February 6, 2026',
-		isoDate: '2026-02-06',
+		publishedAt: '2026-02-06',
 		thumbnail: aiThumbnail
 	},
 	{
@@ -56,8 +61,7 @@ export const blogPosts: BlogPost[] = [
 		slug: 'how-we-work-with-you',
 		description:
 			'How we start projects, keep decisions in Basecamp, use focused weekly calls, and solve problems in writing before scheduling another meeting.',
-		date: 'February 4, 2026',
-		isoDate: '2026-02-04',
+		publishedAt: '2026-02-04',
 		thumbnail: howWeWorkThumbnail
 	}
-];
+] satisfies [BlogPost, ...BlogPost[]];

--- a/src/lib/data/case-studies.ts
+++ b/src/lib/data/case-studies.ts
@@ -1,4 +1,4 @@
-import WasatchFabrication from '../../images/work/wasatch-fabrication.jpg?enhanced';
+import WasatchFabrication from '../../images/work/wasatch-fabrication.jpg?w=320;480;640;800;960;1200&enhanced';
 import AdminDashboard from '../../images/case-study/wasatch-fabrication/admin-dashboard.jpg?enhanced';
 import AdminQuote from '../../images/case-study/wasatch-fabrication/admin-quote.jpg?enhanced';
 import DashboardHome from '../../images/case-study/wasatch-fabrication/dashboard-home.jpg?enhanced';
@@ -9,7 +9,7 @@ import DashboardQuotes from '../../images/case-study/wasatch-fabrication/dashboa
 import MarketingHome from '../../images/case-study/wasatch-fabrication/marketing-home.jpg?enhanced';
 import MarketingService from '../../images/case-study/wasatch-fabrication/marketing-service.jpg?enhanced';
 
-import EnergySafeKidsHome from '../../images/case-study/energysafekids/general-home.jpg?enhanced';
+import EnergySafeKidsHome from '../../images/case-study/energysafekids/general-home.jpg?w=320;480;640;800;960;1200&enhanced';
 import EnergySafeKidsAbout from '../../images/case-study/energysafekids/general-about.jpg?enhanced';
 import EnergySafeKidsTeachers from '../../images/case-study/energysafekids/general-teachers.jpg?enhanced';
 import RockyMountainPowerHome from '../../images/case-study/energysafekids/rmp-home.jpg?enhanced';

--- a/src/lib/data/case-studies.ts
+++ b/src/lib/data/case-studies.ts
@@ -1,4 +1,4 @@
-import WasatchFabrication from '../../images/work/wasatch-fabrication.jpg?w=320;480;640;800;960;1200&enhanced';
+import WasatchFabrication from '../../images/work/wasatch-fabrication.jpg?w=320;480;640;800;960;1200;1440&enhanced';
 import AdminDashboard from '../../images/case-study/wasatch-fabrication/admin-dashboard.jpg?enhanced';
 import AdminQuote from '../../images/case-study/wasatch-fabrication/admin-quote.jpg?enhanced';
 import DashboardHome from '../../images/case-study/wasatch-fabrication/dashboard-home.jpg?enhanced';

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import ContactBanner from '../../components/contact-banner.svelte';
+	import ContentListCard from '../../components/content-list-card.svelte';
+	import ContentPageHero from '../../components/content-page-hero.svelte';
+	import LinkArrow from '../../components/link-arrow.svelte';
 	import Seo from '../../components/seo.svelte';
-	import TopoHeroBg from '../../components/topo-hero-bg.svelte';
-	import { blogPosts } from '$lib/data/blog-posts';
+	import { blogPosts, formatBlogPostDate } from '$lib/data/blog-posts';
 
 	const [featuredPost, ...morePosts] = blogPosts;
 
@@ -19,65 +21,29 @@
 	ogImageAlt="The Bootpack Blog"
 />
 
-<section class="overflow-hidden relative bg-blue-50">
-	<TopoHeroBg />
-	<div class="relative px-4 py-16 mx-auto max-w-7xl sm:px-6 md:py-24 lg:px-8 lg:py-28">
-		<div class="grid gap-8 items-end lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)] lg:gap-20">
-			<div>
-				<p class="mb-5 text-sm font-bold tracking-[0.18em] text-orange-700 uppercase">
-					The Bootpack blog
-				</p>
-				<h1
-					class="max-w-4xl text-4xl font-extrabold tracking-tight leading-[1.04] text-navy-700 sm:text-5xl lg:text-6xl xl:text-7xl"
-				>
-					Notes from the work
-				</h1>
-			</div>
-			<div class="pb-1">
-				<p class="max-w-xl text-lg leading-8 text-navy-600">
-					What we are building, how we test product ideas, and the habits that keep client projects
-					moving.
-				</p>
-				<a
-					class="inline-flex items-center mt-6 font-semibold text-blue-700 underline decoration-blue-300 underline-offset-4 hover:text-blue-500 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600"
-					href={resolve('/work')}
-				>
-					See the work we've shipped
-					<svg aria-hidden="true" class="ml-2 size-4" fill="none" viewBox="0 0 20 20">
-						<path
-							d="m7 4 6 6-6 6"
-							stroke="currentColor"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-						/>
-					</svg>
-				</a>
-			</div>
-		</div>
-	</div>
-</section>
+<ContentPageHero
+	description="What we are building, how we test product ideas, and the habits that keep client projects moving."
+	eyebrow="The Bootpack blog"
+	heading="Notes from the work"
+	linkHref={resolve('/work')}
+	linkText="See the work we've shipped"
+/>
 
 <section class="px-4 py-16 bg-white sm:px-6 md:py-24 lg:px-8 lg:py-28">
 	<div class="mx-auto max-w-7xl">
 		<article
 			class="overflow-hidden w-full bg-navy-800 group lg:grid lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)]"
 		>
-			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-			<a
-				aria-label={featuredPost.title}
-				class="block overflow-hidden min-h-72 bg-blue-100 lg:min-h-[30rem]"
-				href={getBlogPostUrl(featuredPost.slug)}
-			>
+			<div class="overflow-hidden min-h-72 bg-blue-100 lg:min-h-[30rem]">
 				<enhanced:img
 					alt={featuredPost.title}
-					class="object-cover w-full h-full min-h-72 transition-transform duration-500 ease-out group-hover:scale-[1.025] lg:min-h-[30rem]"
+					class="object-cover w-full h-full min-h-72 transition-transform duration-500 ease-out group-hover:scale-[1.025] motion-reduce:transition-none motion-reduce:group-hover:scale-100 lg:min-h-[30rem]"
 					fetchpriority="high"
 					loading="eager"
 					sizes="(min-width: 1024px) min(736px, calc(57.5vw - 37px)), calc(100vw - 32px)"
 					src={featuredPost.thumbnail}
 				/>
-			</a>
+			</div>
 
 			<div class="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
 				<div>
@@ -102,25 +68,17 @@
 						href={getBlogPostUrl(featuredPost.slug)}
 					>
 						Read the post
-						<svg aria-hidden="true" class="size-4" fill="none" viewBox="0 0 20 20">
-							<path
-								d="m7 4 6 6-6 6"
-								stroke="currentColor"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-							/>
-						</svg>
+						<LinkArrow />
 					</a>
-					<time class="text-sm font-medium text-navy-200" datetime={featuredPost.isoDate}>
-						{featuredPost.date}
+					<time class="text-sm font-medium text-navy-200" datetime={featuredPost.publishedAt}>
+						{formatBlogPostDate(featuredPost.publishedAt)}
 					</time>
 				</div>
 			</div>
 		</article>
 
 		<div class="mt-16 mb-12 md:mt-24 md:mb-16">
-			<p class="text-sm font-bold tracking-[0.16em] text-orange-700 uppercase">More posts</p>
+			<p class="text-sm font-bold tracking-[0.16em] text-orange-800 uppercase">More posts</p>
 			<h2 class="mt-3 text-3xl font-bold tracking-tight text-navy-700 sm:text-4xl">
 				What we have been building and learning
 			</h2>
@@ -128,53 +86,20 @@
 
 		<div class="grid gap-x-8 gap-y-16 md:grid-cols-2 lg:gap-y-20 xl:grid-cols-3">
 			{#each morePosts as post (post.slug)}
-				<article class="pt-5 border-t border-blue-200 group">
-					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-					<a
-						aria-label={post.title}
-						class="block overflow-hidden bg-blue-100 rounded-md"
-						href={getBlogPostUrl(post.slug)}
-					>
-						<enhanced:img
-							alt={post.title}
-							class="object-cover w-full transition-transform duration-500 ease-out aspect-[16/10] group-hover:scale-[1.025]"
-							loading="lazy"
-							sizes="(min-width: 1440px) 432px, (min-width: 1280px) calc(33.333vw - 48px), (min-width: 1024px) calc(50vw - 48px), (min-width: 768px) calc(50vw - 40px), calc(100vw - 32px)"
-							src={post.thumbnail}
-						/>
-					</a>
-
-					<div class="pt-6 pb-4">
-						<p class="text-xs font-bold tracking-[0.16em] text-orange-700 uppercase">
-							<time datetime={post.isoDate}>{post.date}</time>
-						</p>
-						<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-						<a class="block" href={getBlogPostUrl(post.slug)}>
-							<h3
-								class="mt-3 text-2xl font-bold tracking-tight leading-tight text-navy-800 hover:underline"
-							>
-								{post.title}
-							</h3>
-							<p class="mt-4 text-base leading-7 text-gray-600">{post.description}</p>
-						</a>
-						<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-						<a
-							class="inline-flex gap-2 items-center mt-7 font-semibold text-blue-700 underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-500"
-							href={getBlogPostUrl(post.slug)}
-						>
-							Read the post
-							<svg aria-hidden="true" class="size-4" fill="none" viewBox="0 0 20 20">
-								<path
-									d="m7 4 6 6-6 6"
-									stroke="currentColor"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-								/>
-							</svg>
-						</a>
-					</div>
-				</article>
+				<ContentListCard
+					description={post.description}
+					href={getBlogPostUrl(post.slug)}
+					image={post.thumbnail}
+					linkText="Read the post"
+					loading="lazy"
+					metadata={{
+						kind: 'date',
+						dateTime: post.publishedAt,
+						text: formatBlogPostDate(post.publishedAt)
+					}}
+					sizes="(min-width: 1440px) 432px, (min-width: 1280px) calc(33.333vw - 48px), (min-width: 1024px) calc(50vw - 48px), (min-width: 768px) calc(50vw - 40px), calc(100vw - 32px)"
+					title={post.title}
+				/>
 			{/each}
 		</div>
 	</div>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import ContactBanner from '../../components/contact-banner.svelte';
 	import Seo from '../../components/seo.svelte';
+	import TopoHeroBg from '../../components/topo-hero-bg.svelte';
 	import { blogPosts } from '$lib/data/blog-posts';
 
-	const posts = blogPosts;
+	const [featuredPost, ...morePosts] = blogPosts;
 
 	// oxlint-disable-next-line @typescript-eslint/no-explicit-any
 	const getBlogPostUrl = (slug: string) => resolve(('/blog/' + slug) as any);
@@ -17,45 +19,169 @@
 	ogImageAlt="The Bootpack Blog"
 />
 
-<div class="py-12 px-4 mx-auto max-w-7xl sm:px-6 lg:px-8">
-	<div class="lg:text-center">
-		<p class="text-base font-semibold tracking-wide uppercase text-blue-600">Blog</p>
-		<h1 class="mt-2 text-3xl font-extrabold leading-8 tracking-tight text-navy-900 sm:text-4xl">
-			Notes from the work
-		</h1>
-		<p class="mt-4 mx-auto max-w-2xl text-lg text-gray-500">
-			What we are building, how we test product ideas, and the habits that keep client projects
-			moving.
-		</p>
-	</div>
-
-	<div class="grid gap-5 mx-auto mt-12 max-w-lg lg:grid-cols-3 lg:max-w-none">
-		{#each posts as post (post.slug)}
-			<div class="flex flex-col overflow-hidden rounded-lg shadow-lg">
-				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-				<a aria-label={post.title} href={getBlogPostUrl(post.slug)} class="block shrink-0">
-					<enhanced:img src={post.thumbnail} alt={post.title} class="h-48 w-full object-cover" />
+<section class="overflow-hidden relative bg-blue-50">
+	<TopoHeroBg />
+	<div class="relative px-4 py-16 mx-auto max-w-7xl sm:px-6 md:py-24 lg:px-8 lg:py-28">
+		<div class="grid gap-8 items-end lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)] lg:gap-20">
+			<div>
+				<p class="mb-5 text-sm font-bold tracking-[0.18em] text-orange-700 uppercase">
+					The Bootpack blog
+				</p>
+				<h1
+					class="max-w-4xl text-4xl font-extrabold tracking-tight leading-[1.04] text-navy-700 sm:text-5xl lg:text-6xl xl:text-7xl"
+				>
+					Notes from the work
+				</h1>
+			</div>
+			<div class="pb-1">
+				<p class="max-w-xl text-lg leading-8 text-navy-600">
+					What we are building, how we test product ideas, and the habits that keep client projects
+					moving.
+				</p>
+				<a
+					class="inline-flex items-center mt-6 font-semibold text-blue-700 underline decoration-blue-300 underline-offset-4 hover:text-blue-500 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600"
+					href={resolve('/work')}
+				>
+					See the work we've shipped
+					<svg aria-hidden="true" class="ml-2 size-4" fill="none" viewBox="0 0 20 20">
+						<path
+							d="m7 4 6 6-6 6"
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+						/>
+					</svg>
 				</a>
-				<div class="flex flex-col justify-between flex-1 p-6 bg-white">
-					<div class="flex-1">
-						<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-						<a href={getBlogPostUrl(post.slug)} class="block mt-2">
-							<p class="text-xl font-semibold text-gray-900">{post.title}</p>
-							<p class="mt-3 text-base text-gray-500">{post.description}</p>
-						</a>
-					</div>
-					<div class="flex items-center mt-6">
-						<div class="flex shrink-0">
-							<span class="sr-only">Bootpack Digital</span>
-						</div>
-						<div>
-							<div class="flex space-x-1 text-sm text-gray-500">
-								<time datetime={post.date}>{post.date}</time>
-							</div>
-						</div>
-					</div>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section class="px-4 py-16 bg-white sm:px-6 md:py-24 lg:px-8 lg:py-28">
+	<div class="mx-auto max-w-7xl">
+		<article
+			class="overflow-hidden w-full bg-navy-800 group lg:grid lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)]"
+		>
+			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+			<a
+				aria-label={featuredPost.title}
+				class="block overflow-hidden min-h-72 bg-blue-100 lg:min-h-[30rem]"
+				href={getBlogPostUrl(featuredPost.slug)}
+			>
+				<enhanced:img
+					alt={featuredPost.title}
+					class="object-cover w-full h-full min-h-72 transition-transform duration-500 ease-out group-hover:scale-[1.025] lg:min-h-[30rem]"
+					fetchpriority="high"
+					loading="eager"
+					sizes="(min-width: 1024px) min(736px, calc(57.5vw - 37px)), calc(100vw - 32px)"
+					src={featuredPost.thumbnail}
+				/>
+			</a>
+
+			<div class="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
+				<div>
+					<p class="text-xs font-bold tracking-[0.16em] text-orange-300 uppercase">Latest post</p>
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+					<a class="block" href={getBlogPostUrl(featuredPost.slug)}>
+						<h2
+							class="mt-3 text-3xl font-bold tracking-tight leading-tight text-white hover:underline sm:text-4xl"
+						>
+							{featuredPost.title}
+						</h2>
+						<p class="mt-4 text-base leading-7 text-navy-100">
+							{featuredPost.description}
+						</p>
+					</a>
+				</div>
+
+				<div class="flex flex-wrap gap-x-6 gap-y-3 items-center mt-7">
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+					<a
+						class="inline-flex gap-2 items-center font-semibold text-white underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-200"
+						href={getBlogPostUrl(featuredPost.slug)}
+					>
+						Read the post
+						<svg aria-hidden="true" class="size-4" fill="none" viewBox="0 0 20 20">
+							<path
+								d="m7 4 6 6-6 6"
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+							/>
+						</svg>
+					</a>
+					<time class="text-sm font-medium text-navy-200" datetime={featuredPost.isoDate}>
+						{featuredPost.date}
+					</time>
 				</div>
 			</div>
-		{/each}
+		</article>
+
+		<div class="mt-16 mb-12 md:mt-24 md:mb-16">
+			<p class="text-sm font-bold tracking-[0.16em] text-orange-700 uppercase">More posts</p>
+			<h2 class="mt-3 text-3xl font-bold tracking-tight text-navy-700 sm:text-4xl">
+				What we have been building and learning
+			</h2>
+		</div>
+
+		<div class="grid gap-x-8 gap-y-16 md:grid-cols-2 lg:gap-y-20 xl:grid-cols-3">
+			{#each morePosts as post (post.slug)}
+				<article class="pt-5 border-t border-blue-200 group">
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+					<a
+						aria-label={post.title}
+						class="block overflow-hidden bg-blue-100 rounded-md"
+						href={getBlogPostUrl(post.slug)}
+					>
+						<enhanced:img
+							alt={post.title}
+							class="object-cover w-full transition-transform duration-500 ease-out aspect-[16/10] group-hover:scale-[1.025]"
+							loading="lazy"
+							sizes="(min-width: 1440px) 432px, (min-width: 1280px) calc(33.333vw - 48px), (min-width: 1024px) calc(50vw - 48px), (min-width: 768px) calc(50vw - 40px), calc(100vw - 32px)"
+							src={post.thumbnail}
+						/>
+					</a>
+
+					<div class="pt-6 pb-4">
+						<p class="text-xs font-bold tracking-[0.16em] text-orange-700 uppercase">
+							<time datetime={post.isoDate}>{post.date}</time>
+						</p>
+						<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+						<a class="block" href={getBlogPostUrl(post.slug)}>
+							<h3
+								class="mt-3 text-2xl font-bold tracking-tight leading-tight text-navy-800 hover:underline"
+							>
+								{post.title}
+							</h3>
+							<p class="mt-4 text-base leading-7 text-gray-600">{post.description}</p>
+						</a>
+						<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+						<a
+							class="inline-flex gap-2 items-center mt-7 font-semibold text-blue-700 underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-500"
+							href={getBlogPostUrl(post.slug)}
+						>
+							Read the post
+							<svg aria-hidden="true" class="size-4" fill="none" viewBox="0 0 20 20">
+								<path
+									d="m7 4 6 6-6 6"
+									stroke="currentColor"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+								/>
+							</svg>
+						</a>
+					</div>
+				</article>
+			{/each}
+		</div>
 	</div>
-</div>
+</section>
+
+<ContactBanner
+	textLine1="Working through a problem like these?"
+	textLine2="Tell us what you're trying to build."
+	bgColor="bg-navy-100"
+/>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -31,25 +31,26 @@
 
 <section class="px-4 py-16 bg-white sm:px-6 md:py-24 lg:px-8 lg:py-28">
 	<div class="mx-auto max-w-7xl">
-		<article
-			class="overflow-hidden w-full bg-navy-800 group lg:grid lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)]"
-		>
-			<div class="overflow-hidden min-h-72 bg-blue-100 lg:min-h-[30rem]">
-				<enhanced:img
-					alt={featuredPost.title}
-					class="object-cover w-full h-full min-h-72 transition-transform duration-500 ease-out group-hover:scale-[1.025] motion-reduce:transition-none motion-reduce:group-hover:scale-100 lg:min-h-[30rem]"
-					fetchpriority="high"
-					loading="eager"
-					sizes="(min-width: 1024px) min(736px, calc(57.5vw - 37px)), calc(100vw - 32px)"
-					src={featuredPost.thumbnail}
-				/>
-			</div>
+		<article class="overflow-hidden w-full bg-navy-800 group">
+			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+			<a
+				class="block focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600 lg:grid lg:grid-cols-[minmax(0,1.15fr)_minmax(20rem,0.85fr)]"
+				href={getBlogPostUrl(featuredPost.slug)}
+			>
+				<div class="overflow-hidden min-h-72 bg-blue-100 lg:min-h-[30rem]">
+					<enhanced:img
+						alt={featuredPost.title}
+						class="object-cover w-full h-full min-h-72 transition-transform duration-500 ease-out group-hover:scale-[1.025] motion-reduce:transition-none motion-reduce:group-hover:scale-100 lg:min-h-[30rem]"
+						fetchpriority="high"
+						loading="eager"
+						sizes="(min-width: 1024px) min(736px, calc(57.5vw - 37px)), calc(100vw - 32px)"
+						src={featuredPost.thumbnail}
+					/>
+				</div>
 
-			<div class="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
-				<div>
-					<p class="text-xs font-bold tracking-[0.16em] text-orange-300 uppercase">Latest post</p>
-					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-					<a class="block" href={getBlogPostUrl(featuredPost.slug)}>
+				<div class="flex flex-col justify-center p-7 sm:p-10 lg:p-12">
+					<div>
+						<p class="text-xs font-bold tracking-[0.16em] text-orange-300 uppercase">Latest post</p>
 						<h2
 							class="mt-3 text-3xl font-bold tracking-tight leading-tight text-white hover:underline sm:text-4xl"
 						>
@@ -58,23 +59,21 @@
 						<p class="mt-4 text-base leading-7 text-navy-100">
 							{featuredPost.description}
 						</p>
-					</a>
-				</div>
+					</div>
 
-				<div class="flex flex-wrap gap-x-6 gap-y-3 items-center mt-7">
-					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-					<a
-						class="inline-flex gap-2 items-center font-semibold text-white underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-200"
-						href={getBlogPostUrl(featuredPost.slug)}
-					>
-						Read the post
-						<LinkArrow />
-					</a>
-					<time class="text-sm font-medium text-navy-200" datetime={featuredPost.publishedAt}>
-						{formatBlogPostDate(featuredPost.publishedAt)}
-					</time>
+					<div class="flex flex-wrap gap-x-6 gap-y-3 items-center mt-7">
+						<span
+							class="inline-flex gap-2 items-center font-semibold text-white underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-200"
+						>
+							Read the post
+							<LinkArrow />
+						</span>
+						<time class="text-sm font-medium text-navy-200" datetime={featuredPost.publishedAt}>
+							{formatBlogPostDate(featuredPost.publishedAt)}
+						</time>
+					</div>
 				</div>
-			</div>
+			</a>
 		</article>
 
 		<div class="mt-16 mb-12 md:mt-24 md:mb-16">

--- a/src/routes/case-studies/+page.svelte
+++ b/src/routes/case-studies/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import ContactBanner from '../../components/contact-banner.svelte';
 	import Seo from '../../components/seo.svelte';
+	import TopoHeroBg from '../../components/topo-hero-bg.svelte';
 	import { caseStudies } from '$lib/data/case-studies';
-	import { resolve } from '$app/paths';
 </script>
 
 <Seo
@@ -28,52 +29,106 @@
 	}}
 />
 
-<div class="px-4 pt-16 pb-20 bg-white sm:px-6 lg:px-8 lg:pb-28">
+<section class="overflow-hidden relative bg-blue-50">
+	<TopoHeroBg />
+	<div class="relative px-4 py-16 mx-auto max-w-7xl sm:px-6 md:py-24 lg:px-8 lg:py-28">
+		<div class="grid gap-8 items-end lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)] lg:gap-20">
+			<div>
+				<p class="mb-5 text-sm font-bold tracking-[0.18em] text-orange-700 uppercase">
+					Case studies
+				</p>
+				<h1
+					class="max-w-4xl text-4xl font-extrabold tracking-tight leading-[1.04] text-navy-700 sm:text-5xl lg:text-6xl xl:text-7xl"
+				>
+					The full story behind the work, from first call to launch.
+				</h1>
+			</div>
+			<div class="pb-1">
+				<p class="max-w-xl text-lg leading-8 text-navy-600">
+					See how we replaced repeated content updates with one shared platform and turned an
+					operations workflow into working software in under six weeks.
+				</p>
+				<a
+					class="inline-flex items-center mt-6 font-semibold text-blue-700 underline decoration-blue-300 underline-offset-4 hover:text-blue-500 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600"
+					href={resolve('/work')}
+				>
+					See more of the work we've shipped
+					<svg aria-hidden="true" class="ml-2 size-4" fill="none" viewBox="0 0 20 20">
+						<path
+							d="m7 4 6 6-6 6"
+							stroke="currentColor"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+						/>
+					</svg>
+				</a>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section class="px-4 py-16 bg-white sm:px-6 md:py-24 lg:px-8 lg:py-28">
 	<div class="mx-auto max-w-7xl">
-		<div class="prose lg:prose-lg text-gray-600">
-			<h1 class="tracking-tight text-navy-600">Case Studies</h1>
-			<p>
-				See how we replaced repeated content updates with one shared platform and turned an
-				operations workflow into working software in under six weeks.
+		<div class="grid gap-6 items-end mb-12 md:grid-cols-[1fr_auto] md:mb-16">
+			<div>
+				<p class="text-sm font-bold tracking-[0.16em] text-orange-700 uppercase">Selected builds</p>
+				<h2 class="mt-3 text-3xl font-bold tracking-tight text-navy-700 sm:text-4xl">
+					Problems worth solving, start to finish
+				</h2>
+			</div>
+			<p class="max-w-md text-base leading-7 text-gray-600 md:text-right">
+				What the client needed, what we built, and what changed once it shipped.
 			</p>
 		</div>
-		<div class="grid gap-x-5 gap-y-10 mx-auto mt-12 max-w-lg lg:grid-cols-2 lg:max-w-none">
-			{#each caseStudies as study}
-				<div
-					class="flex flex-col overflow-hidden rounded-lg shadow-lg transition-transform hover:-translate-y-1 hover:scale-[101%]"
-				>
+
+		<div class="grid gap-x-8 gap-y-16 lg:grid-cols-2 lg:gap-y-20">
+			{#each caseStudies as study (study.slug)}
+				<article class="pt-5 border-t border-blue-200 group">
 					<a
-						href={resolve(`/case-studies/${study.slug}`)}
-						class="shrink-0 bg-blue-100"
 						aria-label={study.title}
+						class="block overflow-hidden bg-blue-100 rounded-md"
+						href={resolve(`/case-studies/${study.slug}`)}
 					>
-						<enhanced:img class="w-full h-48 object-cover" src={study.image} alt={study.title} />
+						<enhanced:img
+							alt={study.title}
+							class="object-cover w-full transition-transform duration-500 ease-out aspect-[16/10] group-hover:scale-[1.025]"
+							sizes="(min-width: 1280px) 592px, (min-width: 1024px) calc(50vw - 48px), calc(100vw - 32px)"
+							src={study.image}
+						/>
 					</a>
-					<div class="flex flex-col flex-1 justify-between p-6 bg-white">
-						<div class="flex-1">
-							<a href={resolve(`/case-studies/${study.slug}`)} class="block">
-								<h3 class="mt-2 text-xl font-semibold leading-7 text-gray-900">
-									{study.title}
-								</h3>
-								<p class="mt-3 text-base leading-6 text-gray-500">
-									{study.description}
-								</p>
-							</a>
-						</div>
-						<div class="mt-6">
-							<a
-								href={resolve(`/case-studies/${study.slug}`)}
-								class="text-base font-semibold text-blue-600 hover:text-blue-500"
+
+					<div class="pt-6 pb-4">
+						<p class="text-xs font-bold tracking-[0.16em] text-orange-700 uppercase">Case study</p>
+						<a class="block" href={resolve(`/case-studies/${study.slug}`)}>
+							<h3
+								class="mt-3 text-2xl font-bold tracking-tight leading-tight text-navy-800 hover:underline sm:text-3xl"
 							>
-								Read full case study <span aria-hidden="true">&rarr;</span>
-							</a>
-						</div>
+								{study.title}
+							</h3>
+							<p class="mt-4 text-base leading-7 text-gray-600">{study.description}</p>
+						</a>
+						<a
+							class="inline-flex gap-2 items-center mt-7 font-semibold text-blue-700 underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-500"
+							href={resolve(`/case-studies/${study.slug}`)}
+						>
+							Read the full case study
+							<svg aria-hidden="true" class="size-4" fill="none" viewBox="0 0 20 20">
+								<path
+									d="m7 4 6 6-6 6"
+									stroke="currentColor"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									stroke-width="2"
+								/>
+							</svg>
+						</a>
 					</div>
-				</div>
+				</article>
 			{/each}
 		</div>
 	</div>
-</div>
+</section>
 
 <ContactBanner
 	textLine1="Have a workflow that needs better software?"

--- a/src/routes/case-studies/+page.svelte
+++ b/src/routes/case-studies/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import ContactBanner from '../../components/contact-banner.svelte';
+	import ContentListCard from '../../components/content-list-card.svelte';
+	import ContentPageHero from '../../components/content-page-hero.svelte';
 	import Seo from '../../components/seo.svelte';
-	import TopoHeroBg from '../../components/topo-hero-bg.svelte';
 	import { caseStudies } from '$lib/data/case-studies';
 </script>
 
@@ -29,50 +30,19 @@
 	}}
 />
 
-<section class="overflow-hidden relative bg-blue-50">
-	<TopoHeroBg />
-	<div class="relative px-4 py-16 mx-auto max-w-7xl sm:px-6 md:py-24 lg:px-8 lg:py-28">
-		<div class="grid gap-8 items-end lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)] lg:gap-20">
-			<div>
-				<p class="mb-5 text-sm font-bold tracking-[0.18em] text-orange-700 uppercase">
-					Case studies
-				</p>
-				<h1
-					class="max-w-4xl text-4xl font-extrabold tracking-tight leading-[1.04] text-navy-700 sm:text-5xl lg:text-6xl xl:text-7xl"
-				>
-					The full story behind the work, from first call to launch.
-				</h1>
-			</div>
-			<div class="pb-1">
-				<p class="max-w-xl text-lg leading-8 text-navy-600">
-					See how we replaced repeated content updates with one shared platform and turned an
-					operations workflow into working software in under six weeks.
-				</p>
-				<a
-					class="inline-flex items-center mt-6 font-semibold text-blue-700 underline decoration-blue-300 underline-offset-4 hover:text-blue-500 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600"
-					href={resolve('/work')}
-				>
-					See more of the work we've shipped
-					<svg aria-hidden="true" class="ml-2 size-4" fill="none" viewBox="0 0 20 20">
-						<path
-							d="m7 4 6 6-6 6"
-							stroke="currentColor"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-						/>
-					</svg>
-				</a>
-			</div>
-		</div>
-	</div>
-</section>
+<ContentPageHero
+	description="See how we replaced repeated content updates with one shared platform and turned an operations workflow into working software in under six weeks."
+	eyebrow="Case studies"
+	heading="The full story behind the work, from first call to launch."
+	linkHref={resolve('/work')}
+	linkText="See more of the work we've shipped"
+/>
 
 <section class="px-4 py-16 bg-white sm:px-6 md:py-24 lg:px-8 lg:py-28">
 	<div class="mx-auto max-w-7xl">
 		<div class="grid gap-6 items-end mb-12 md:grid-cols-[1fr_auto] md:mb-16">
 			<div>
-				<p class="text-sm font-bold tracking-[0.16em] text-orange-700 uppercase">Selected builds</p>
+				<p class="text-sm font-bold tracking-[0.16em] text-orange-800 uppercase">Selected builds</p>
 				<h2 class="mt-3 text-3xl font-bold tracking-tight text-navy-700 sm:text-4xl">
 					Problems worth solving, start to finish
 				</h2>
@@ -84,47 +54,16 @@
 
 		<div class="grid gap-x-8 gap-y-16 lg:grid-cols-2 lg:gap-y-20">
 			{#each caseStudies as study (study.slug)}
-				<article class="pt-5 border-t border-blue-200 group">
-					<a
-						aria-label={study.title}
-						class="block overflow-hidden bg-blue-100 rounded-md"
-						href={resolve(`/case-studies/${study.slug}`)}
-					>
-						<enhanced:img
-							alt={study.title}
-							class="object-cover w-full transition-transform duration-500 ease-out aspect-[16/10] group-hover:scale-[1.025]"
-							sizes="(min-width: 1280px) 592px, (min-width: 1024px) calc(50vw - 48px), calc(100vw - 32px)"
-							src={study.image}
-						/>
-					</a>
-
-					<div class="pt-6 pb-4">
-						<p class="text-xs font-bold tracking-[0.16em] text-orange-700 uppercase">Case study</p>
-						<a class="block" href={resolve(`/case-studies/${study.slug}`)}>
-							<h3
-								class="mt-3 text-2xl font-bold tracking-tight leading-tight text-navy-800 hover:underline sm:text-3xl"
-							>
-								{study.title}
-							</h3>
-							<p class="mt-4 text-base leading-7 text-gray-600">{study.description}</p>
-						</a>
-						<a
-							class="inline-flex gap-2 items-center mt-7 font-semibold text-blue-700 underline decoration-1 decoration-blue-300 underline-offset-4 transition-colors hover:text-blue-500"
-							href={resolve(`/case-studies/${study.slug}`)}
-						>
-							Read the full case study
-							<svg aria-hidden="true" class="size-4" fill="none" viewBox="0 0 20 20">
-								<path
-									d="m7 4 6 6-6 6"
-									stroke="currentColor"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-								/>
-							</svg>
-						</a>
-					</div>
-				</article>
+				<ContentListCard
+					description={study.description}
+					href={resolve(`/case-studies/${study.slug}`)}
+					image={study.image}
+					linkText="Read the full case study"
+					metadata={{ kind: 'label', text: 'Case study' }}
+					sizes="(min-width: 1280px) 592px, (min-width: 1024px) calc(50vw - 48px), calc(100vw - 32px)"
+					title={study.title}
+					titleSize="large"
+				/>
 			{/each}
 		</div>
 	</div>


### PR DESCRIPTION
Brings `/blog` and `/case-studies` onto the same design system as the redesigned `/work` (#372) and `/about` (#378) pages.

## Blog

- Topo hero (`TopoHeroBg` over `bg-blue-50`) with the orange tracked eyebrow, oversized navy `h1`, and a right-hand lead column linking to `/work`
- Latest post promoted to a full-width navy-800 featured panel, mirroring the featured work item
- Remaining posts moved from shadowed cards to the `border-t border-blue-200` treatment: rounded 16/10 image with hover scale, date as the eyebrow, navy-800 title, blue "Read the post" link
- Added the `ContactBanner` the page was missing

## Case studies

- Same topo hero in place of the old prose header; existing lead copy kept
- Section header with eyebrow plus right-aligned support line
- Studies rendered as two-up cards in the shared card style

## Data

- `blog-posts.ts`: thumbnails imported with responsive widths so the new `sizes` attributes get a srcset; added `isoDate` because the visible date string is not a valid `<time datetime>` value
- `case-studies.ts`: same width query on the two card images (used only on the index)

## Verification

- `bun run build` and `bun run lint` pass (only the pre-existing `scripts/dokploy-preview.mjs` warning)
- Checked both pages in a browser at desktop and 430px
- `bun run check` still reports the 3 pre-existing `vite.config.js` errors, untouched here
- No e2e tests cover these routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned blog page with a featured post, publication dates, responsive post cards, and contact banner.
  * Added a refreshed case studies page with reusable hero and content cards.
  * Added responsive content cards, page heroes, and accessible arrow links.
* **Improvements**
  * Improved image loading across blog posts and case studies for responsive performance.
  * Standardized publication date formatting and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->