### PR TITLE
Redesign the contact page

### DIFF
--- a/src/components/contact-form.svelte
+++ b/src/components/contact-form.svelte
@@ -81,21 +81,21 @@
   <div class="flex flex-wrap -mx-3 mt-8 mb-6">
     <div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
       <label
-        class="block mb-2 text-xs font-bold tracking-wide text-gray-700"
+        class="block mb-2 text-xs font-bold tracking-[0.16em] text-navy-700 uppercase"
         for="firstName"
       >
         First Name*
       </label>
       <input
         aria-required="true"
-        class="block py-3 px-4 w-full leading-tight text-gray-700 bg-gray-100 rounded-sm border border-gray-100 appearance-none focus:bg-white focus:border-gray-500 focus:outline-hidden"
+        class="block py-3 px-4 w-full text-base text-navy-800 bg-white rounded-lg border border-blue-200 appearance-none transition-colors placeholder:text-gray-400 focus:border-blue-500 focus:outline-2 focus:outline-offset-2 focus:outline-blue-400"
         id="firstName"
         name="firstName"
         placeholder="Jane"
         required
         type="text"
       />
-      <p class="px-2 pt-1 text-xs italic text-red-500">
+      <p class="px-2 pt-1 text-xs font-medium text-orange-700">
         {#if errors.firstName && touched.firstName}
           {errors.firstName}
         {/if}
@@ -103,21 +103,21 @@
     </div>
     <div class="px-3 w-full md:w-1/2">
       <label
-        class="block mb-2 text-xs font-bold tracking-wide text-gray-700"
+        class="block mb-2 text-xs font-bold tracking-[0.16em] text-navy-700 uppercase"
         for="lastName"
       >
         Last Name*
       </label>
       <input
         aria-required="true"
-        class="block py-3 px-4 w-full leading-tight text-gray-700 bg-gray-100 rounded-sm border border-gray-100 appearance-none focus:bg-white focus:border-gray-500 focus:outline-hidden"
+        class="block py-3 px-4 w-full text-base text-navy-800 bg-white rounded-lg border border-blue-200 appearance-none transition-colors placeholder:text-gray-400 focus:border-blue-500 focus:outline-2 focus:outline-offset-2 focus:outline-blue-400"
         id="lastName"
         name="lastName"
         placeholder="Doe"
         required
         type="text"
       />
-      <p class="px-2 pt-1 text-xs italic text-red-500">
+      <p class="px-2 pt-1 text-xs font-medium text-orange-700">
         {#if errors.lastName && touched.lastName}
           {errors.lastName}
         {/if}
@@ -127,14 +127,14 @@
   <div class="flex flex-wrap -mx-3 mb-6">
     <div class="px-3 mb-0 w-full">
       <label
-        class="block mb-2 text-xs font-bold tracking-wide text-gray-700"
+        class="block mb-2 text-xs font-bold tracking-[0.16em] text-navy-700 uppercase"
         for="email"
       >
         Email*
       </label>
       <input
         aria-required="true"
-        class="block py-3 px-4 w-full leading-tight text-gray-700 bg-gray-100 rounded-sm border border-gray-100 appearance-none focus:bg-white focus:border-gray-500 focus:outline-hidden"
+        class="block py-3 px-4 w-full text-base text-navy-800 bg-white rounded-lg border border-blue-200 appearance-none transition-colors placeholder:text-gray-400 focus:border-blue-500 focus:outline-2 focus:outline-offset-2 focus:outline-blue-400"
         id="email"
         name="email"
         placeholder="jane@company.com"
@@ -149,13 +149,13 @@
   <div class="flex flex-wrap -mx-3 mb-6">
     <div class="px-3 mb-6 w-full md:mb-0 md:w-1/2">
       <label
-        class="block mb-2 text-xs font-bold tracking-wide text-gray-700"
+        class="block mb-2 text-xs font-bold tracking-[0.16em] text-navy-700 uppercase"
         for="company"
       >
         Company
       </label>
       <input
-        class="block py-3 px-4 w-full leading-tight text-gray-700 bg-gray-100 rounded-sm border border-gray-100 appearance-none focus:bg-white focus:border-gray-500 focus:outline-hidden"
+        class="block py-3 px-4 w-full text-base text-navy-800 bg-white rounded-lg border border-blue-200 appearance-none transition-colors placeholder:text-gray-400 focus:border-blue-500 focus:outline-2 focus:outline-offset-2 focus:outline-blue-400"
         id="company"
         name="company"
         placeholder="Company Name"
@@ -167,13 +167,13 @@
     </div>
     <div class="px-3 w-full md:w-1/2">
       <label
-        class="block mb-2 text-xs font-bold tracking-wide text-gray-700"
+        class="block mb-2 text-xs font-bold tracking-[0.16em] text-navy-700 uppercase"
         for="phone"
       >
         Phone Number
       </label>
       <input
-        class="block py-3 px-4 w-full leading-tight text-gray-700 bg-gray-100 rounded-sm border border-gray-100 appearance-none focus:bg-white focus:border-gray-500 focus:outline-hidden"
+        class="block py-3 px-4 w-full text-base text-navy-800 bg-white rounded-lg border border-blue-200 appearance-none transition-colors placeholder:text-gray-400 focus:border-blue-500 focus:outline-2 focus:outline-offset-2 focus:outline-blue-400"
         id="phone"
         name="phone"
         placeholder="801-111-2222"
@@ -187,52 +187,59 @@
   <div class="flex flex-wrap -mx-3 mb-6">
     <div class="px-3 mb-6 w-full md:mb-0">
       <label
-        class="block mb-2 text-xs font-bold tracking-wide text-gray-700"
+        class="block mb-2 text-xs font-bold tracking-[0.16em] text-navy-700 uppercase"
         for="message"
       >
         How Can We Help?*
       </label>
       <textarea
         aria-required="true"
-        class="block py-3 px-4 w-full leading-tight text-gray-700 bg-gray-100 rounded-sm border border-gray-100 appearance-none focus:bg-white focus:border-gray-500 focus:outline-hidden"
+        class="block py-3 px-4 w-full text-base text-navy-800 bg-white rounded-lg border border-blue-200 appearance-none transition-colors placeholder:text-gray-400 focus:border-blue-500 focus:outline-2 focus:outline-offset-2 focus:outline-blue-400"
         id="message"
         name="message"
         placeholder="Please give us details about what you're trying to accomplish"
         required
         rows={10}
       ></textarea>
-      <p class="px-2 pt-1 text-xs italic text-red-500">
+      <p class="px-2 pt-1 text-xs font-medium text-orange-700">
         {#if errors.message && touched.message}
           {errors.message}
         {/if}
       </p>
     </div>
   </div>
-  <div class={clsx("mb-6 flex justify-start", "xl:justify-end")}>
+  <div class="flex justify-start mb-6 sm:justify-end">
     <Turnstile />
   </div>
   {#if errorMessage}
-    <p class="px-2 pt-1 text-xs italic text-red-500">
+    <p class="pb-3 text-sm font-medium text-orange-700">
       {errorMessage}
     </p>
   {/if}
-  <div class={clsx("flex justify-start", "xl:justify-end")}>
+  <div class="flex justify-start sm:justify-end">
     <button
       class={clsx(
-        "py-3 px-5 w-full text-base font-medium leading-6 text-white bg-orange-700 rounded-md border border-transparent transition duration-150 ease-in-out",
-        "lg:w-auto",
+        "py-3 px-6 w-full text-base font-semibold text-white bg-orange-700 rounded-lg transition-colors",
+        "sm:w-auto",
         "hover:bg-orange-600",
-        "focus:outline-hidden focus:shadow-outline",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-navy-600",
+        "disabled:opacity-60 disabled:cursor-not-allowed",
       )}
       disabled={isSubmitting}
       type="submit"
     >
-      Send message
+      {isSubmitting ? "Sending..." : "Send message"}
     </button>
   </div>
 </form>
 <div class={submitted ? `visible` : `hidden`}>
-  <h2>
-    Thanks for reaching out! We'll get back to you within one business day.
-  </h2>
+  <div class="p-7 mt-8 bg-blue-50 rounded-2xl border border-blue-200 sm:p-8">
+    <p class="text-xs font-bold tracking-[0.16em] text-orange-700 uppercase">Message sent</p>
+    <h3 class="mt-3 text-2xl font-bold tracking-tight text-navy-700">
+      Thanks for reaching out!
+    </h3>
+    <p class="mt-3 text-base leading-7 text-gray-600">
+      We'll get back to you within one business day.
+    </p>
+  </div>
 </div>

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Obfuscate } from 'svelte-obfuscate';
 	import ContactForm from '../../components/contact-form.svelte';
+	import ContentPageHero from '../../components/content-page-hero.svelte';
 	import Seo from '../../components/seo.svelte';
-	import clsx from 'clsx';
 </script>
 
 <Seo
@@ -13,185 +14,188 @@
 	ogImageAlt="Contact Bootpack Digital"
 />
 
-<div class="px-4 pt-16 pb-20 bg-white sm:px-6 lg:px-8">
+<ContentPageHero
+	description="You'll talk to Michael Bonner, the founder, not a salesperson or an intern. We take on custom web design, web development, and app development, and we reply within one business day."
+	eyebrow="Get in touch"
+	heading="Tell us what you're building and we'll tell you how we'd build it."
+	linkHref={resolve('/work')}
+	linkText="See the work we've shipped"
+/>
+
+<section class="px-4 py-16 bg-white sm:px-6 md:py-24 lg:px-8 lg:py-28">
 	<div class="mx-auto max-w-7xl">
-		<div class="text-gray-700 xl:flex xl:gap-16 xl:px-8 2xl:px-0">
-			<div class="max-w-3xl mx-auto">
-				<div class="prose lg:prose-lg text-gray-600">
-					<h1 class="text-navy-600">Get in touch</h1>
-					<p>
-						Set up some time to talk to Michael Bonner, the founder, not a salesperson or an intern.
+		<div class="grid gap-6 items-end mb-12 md:grid-cols-[1fr_auto] md:mb-16">
+			<div>
+				<p class="text-sm font-bold tracking-[0.16em] text-orange-700 uppercase">
+					Start a conversation
+				</p>
+				<h2 class="mt-3 text-3xl font-bold tracking-tight text-navy-700 sm:text-4xl">
+					Two easy ways to reach us
+				</h2>
+			</div>
+			<p class="max-w-md text-base leading-7 text-gray-600 md:text-right">
+				Book a call if you would rather talk it through, or send the form if you would rather write it
+				out. Both land with the person who will do the work.
+			</p>
+		</div>
+
+		<div class="grid gap-12 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)] lg:gap-16">
+			<div>
+				<div class="p-7 bg-blue-50 rounded-2xl border border-blue-200 sm:p-8">
+					<svg
+						aria-hidden="true"
+						class="size-8 text-blue-600"
+						fill="none"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="32"
+						viewBox="0 0 512 512"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							d="M374.79 308.78L457.5 367a16 16 0 0022.5-14.62V159.62A16 16 0 00457.5 145l-82.71 58.22A16 16 0 00368 216.3v79.4a16 16 0 006.79 13.08z"
+						/>
+						<rect height="288" rx="64" ry="64" width="336" x="32" y="112" />
+					</svg>
+					<h3 class="mt-5 text-2xl font-bold tracking-tight text-navy-700">
+						Schedule a 30-minute call
+					</h3>
+					<p class="mt-3 text-base leading-7 text-gray-600">
+						Pick a time that works and we will talk through what you are trying to accomplish. No
+						prep required, no pitch deck.
 					</p>
-					<p>
-						We love meeting new people and hearing ideas. Our goal is to help you build your
-						website, mobile app, or web app. We'll work with you to understand what you need, and
-						we'll make it happen.
-					</p>
-					<p>
-						Do you have a project idea or an existing site that needs to be updated? Do you need an
-						outside consultant? Fill out this form and we'll get back to you within one business day. We
-						specialize in custom
-						web design, web development, and app development.
-					</p>
-					<p>
+					<a
+						class="inline-flex gap-2 items-center py-3 px-5 mt-6 text-base font-semibold text-white bg-navy-700 rounded-lg transition-colors hover:bg-navy-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-navy-600"
+						href="https://savvycal.com/bootpack/30-minute-project-discussion?utm_source=bootpack_website"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Book a time
+						<span class="sr-only">(opens a new tab)</span>
+						<svg aria-hidden="true" class="size-4" fill="none" viewBox="0 0 20 20">
+							<path
+								d="m7 4 6 6-6 6"
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+							/>
+						</svg>
+					</a>
+				</div>
+
+				<dl class="mt-10 border-blue-200 divide-y divide-blue-200 border-y">
+					<div class="py-6">
+						<dt
+							class="flex gap-2 items-center text-xs font-bold tracking-[0.16em] text-orange-700 uppercase"
+						>
+							<svg
+								aria-hidden="true"
+								class="size-4"
+								fill="none"
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="32"
+								viewBox="0 0 512 512"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<rect height="480" rx="48" ry="48" width="256" x="128" y="16" />
+								<path
+									d="M176 16h24a8 8 0 018 8h0a16 16 0 0016 16h64a16 16 0 0016-16h0a8 8 0 018-8h24"
+								/>
+							</svg>
+							Phone
+						</dt>
+						<dd class="mt-2 text-lg font-semibold text-navy-700 hover:underline">
+							<Obfuscate telephone="(801) 839-5287" />
+						</dd>
+					</div>
+
+					<div class="py-6">
+						<dt
+							class="flex gap-2 items-center text-xs font-bold tracking-[0.16em] text-orange-700 uppercase"
+						>
+							<svg
+								aria-hidden="true"
+								class="size-4"
+								fill="none"
+								stroke="currentColor"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="32"
+								viewBox="0 0 512 512"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<rect height="320" rx="40" ry="40" width="416" x="48" y="96" />
+								<path d="M112 160l144 112 144-112" />
+							</svg>
+							Email
+						</dt>
+						<dd class="mt-2 text-lg font-semibold text-navy-700 hover:underline">
+							<Obfuscate email="hey@bootpackdigital.com" />
+						</dd>
+					</div>
+
+					<div class="py-6">
+						<dt
+							class="flex gap-2 items-center text-xs font-bold tracking-[0.16em] text-orange-700 uppercase"
+						>
+							<svg
+								aria-hidden="true"
+								class="size-4"
+								fill="none"
+								stroke="currentColor"
+								stroke-miterlimit="10"
+								stroke-width="32"
+								viewBox="0 0 512 512"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									d="M336.76 161l-186.53 82.35c-10.47 4.8-6.95 20.67 4.57 20.67H244a4 4 0 014 4v89.18c0 11.52 16 15 20.78 4.56L351 175.24A10.73 10.73 0 00336.76 161z"
+									fill="currentColor"
+									stroke="none"
+								/>
+								<path d="M448 256c0-106-86-192-192-192S64 150 64 256s86 192 192 192 192-86 192-192z" />
+							</svg>
+							Mailing address
+						</dt>
+						<dd class="mt-2 text-lg font-semibold text-navy-700">
+							PO Box 711235
+							<br />
+							Salt Lake City, UT 84171
+						</dd>
+					</div>
+				</dl>
+
+				<div class="mt-10 space-y-5">
+					<p class="text-base leading-7 text-gray-600">
 						Looking for a job? Check out our <a
+							class="font-semibold text-blue-700 underline decoration-blue-300 underline-offset-4 hover:text-blue-800 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600"
 							href="https://joblisting.app/w/66997a29-eadf-42b1-b1da-0dce217cbe19"
-							target="_blank"
-							rel="noopener noreferrer">available job listings</a
+							rel="noopener noreferrer"
+							target="_blank">available job listings</a
 						>.
 					</p>
-					<p>
-						Run a Salt Lake-area nonprofit or community organization? We give away a free
-						website every quarter through <a href="/bootpack-for-good">Bootpack for Good</a>.
+					<p class="text-base leading-7 text-gray-600">
+						Run a Salt Lake-area nonprofit or community organization? We give away a free website
+						every quarter through <a
+							class="font-semibold text-blue-700 underline decoration-blue-300 underline-offset-4 hover:text-blue-800 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-navy-600"
+							href={resolve('/bootpack-for-good')}>Bootpack for Good</a
+						>.
 					</p>
-					<div>
-						<a
-							class="inline-flex py-3 px-5 text-base font-medium leading-6 text-white bg-blue-600 rounded-md border border-transparent transition duration-150 ease-in-out lg:w-auto hover:bg-blue-500 focus:outline-hidden focus:shadow-outline"
-							href="https://savvycal.com/bootpack/30-minute-project-discussion?utm_source=bootpack_website"
-							rel="noopener noreferrer"
-							target="_blank"
-						>
-							<span class="flex gap-2 items-center mr-2 text-white">
-								<svg
-									aria-hidden="true"
-									class="w-6 h-6 text-white"
-									viewBox="0 0 512 512"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<path
-										d="M374.79 308.78L457.5 367a16 16 0 0022.5-14.62V159.62A16 16 0 00457.5 145l-82.71 58.22A16 16 0 00368 216.3v79.4a16 16 0 006.79 13.08z"
-										fill="none"
-										stroke="currentColor"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="32"
-									/>
-									<rect
-										fill="none"
-										height="288"
-										rx="64"
-										ry="64"
-										stroke="currentColor"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="32"
-										width="336"
-										x="32"
-										y="112"
-									/>
-								</svg>
-								Schedule a 30-minute video call
-								<span class="sr-only"> (opens a new tab)</span>
-							</span>
-						</a>
-					</div>
-				</div>
-				<div class="pt-4 w-full">
-					<div class="flex flex-wrap justify-between items-end">
-						<div>
-							<div class="flex items-center mt-4">
-								<svg
-									class="w-6 h-5 text-blue-600 fill-current"
-									viewBox="0 0 512 512"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<title>Phone</title>
-									<rect
-										fill="none"
-										height="480"
-										rx="48"
-										ry="48"
-										stroke="currentColor"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="32"
-										width="256"
-										x="128"
-										y="16"
-									/>
-									<path
-										d="M176 16h24a8 8 0 018 8h0a16 16 0 0016 16h64a16 16 0 0016-16h0a8 8 0 018-8h24"
-										fill="none"
-										stroke="currentColor"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="32"
-									/>
-								</svg>
-								<p class="ml-2 hover:underline">
-									<Obfuscate telephone="(801) 839-5287" />
-								</p>
-							</div>
-							<div class="flex items-center mt-4">
-								<svg
-									class="w-6 h-5 text-blue-600 fill-current"
-									viewBox="0 0 512 512"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<title>Mail</title>
-									<rect
-										fill="none"
-										height="320"
-										rx="40"
-										ry="40"
-										stroke="currentColor"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="32"
-										width="416"
-										x="48"
-										y="96"
-									/>
-									<path
-										d="M112 160l144 112 144-112"
-										fill="none"
-										stroke="currentColor"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="32"
-									/>
-								</svg>
-								<p class="ml-2 hover:underline">
-									<Obfuscate email="hey@bootpackdigital.com" />
-								</p>
-							</div>
-							<div class="flex items-center mt-4">
-								<svg
-									class="w-6 h-5 text-blue-600 fill-current"
-									viewBox="0 0 512 512"
-									xmlns="http://www.w3.org/2000/svg"
-								>
-									<title>Address</title>
-									<path
-										d="M336.76 161l-186.53 82.35c-10.47 4.8-6.95 20.67 4.57 20.67H244a4 4 0 014 4v89.18c0 11.52 16 15 20.78 4.56L351 175.24A10.73 10.73 0 00336.76 161z"
-									/>
-									<path
-										d="M448 256c0-106-86-192-192-192S64 150 64 256s86 192 192 192 192-86 192-192z"
-										fill="none"
-										stroke="currentColor"
-										stroke-miterlimit="10"
-										stroke-width="32"
-									/>
-								</svg>
-								<p class="ml-2">
-									PO Box 711235
-									<br />
-									Salt Lake City, UT 84171
-								</p>
-							</div>
-						</div>
-					</div>
 				</div>
 			</div>
-			<section
-				class={clsx(
-					'pt-6 pb-24 mx-auto mt-8 w-full max-w-3xl border-t',
-					'lg:pt-8 lg:mt-12',
-					'xl:mt-0 xl:border-t-0 xl:border-l xl:pl-16 xl:max-w-lg xl:pt-0'
-				)}
-			>
+
+			<div class="lg:pl-4">
+				<h3 class="text-2xl font-bold tracking-tight text-navy-700">Send us a note</h3>
+				<p class="mt-3 text-base leading-7 text-gray-600">
+					Tell us what you are trying to accomplish and we will get back to you within one business
+					day.
+				</p>
 				<ContactForm />
-			</section>
+			</div>
 		</div>
 	</div>
-</div>
+</section>


### PR DESCRIPTION
`/contact` was the last main page still on the pre-redesign layout: a `prose` block with the `h1` inside it, no hero, and the older `bg-blue-600` rounded button. This rebuilds it on the patterns that `work`, `about`, `blog`, and `case-studies` now share.

## Page

- Leads with `ContentPageHero`, so the page picks up the topo hero background, the brand red eyebrow, and the extrabold navy-700 heading used everywhere else.
- Body splits into two columns under one section heading: a scheduling card on the left, the form on the right. Previously the copy stacked above the form in a `prose` block.
- Phone, email, and mailing address moved into a labeled definition list using the `divide-y border-y border-blue-200` treatment from the error page.
- Job listings and Bootpack for Good links are kept. The "custom web design, web development, and app development" copy moved into the hero description so the keywords stay on the page.
- The savvycal scheduling link is now a navy button inside its own card, so it does not compete with the orange submit button on the form.

## Form

`contact-form.svelte` is only used on this page, so it was restyled to match:

- Uppercase navy labels, white fields with `blue-200` borders and a blue focus ring, replacing the gray-100 boxes.
- Validation and submit errors use the brand red (`orange-700`) instead of Tailwind's default `red-500`, which is not in the palette.
- Submit button gains a sending state and a disabled style.
- The success message was a bare unstyled `h2`; it is now a card matching the scheduling card beside it.

Label text is unchanged, so the existing accessible names (`First Name*`, `Send message`, and so on) still resolve.

## Verification

- `bun run test:e2e` — 3 passed, including the contact form submission test.
- `bun run lint` — clean.
- `bun run check` — the 3 pre-existing `vite.config.js` errors, no new ones.
- Checked at 390px, 820px, and 1440px. No horizontal overflow at any width.

## Not fixed here

At tablet widths the shared `md:grid-cols-[1fr_auto]` section header squeezes the `h2` into a narrow column while the supporting paragraph keeps its `max-w-md`. This is pre-existing and shows up worse on `/work` ("A few projects we are proud to put our name on" wraps to five lines at 820px). Left alone here for consistency; worth a follow-up across all the pages that use the pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the contact page with a clearer two-column layout and dedicated contact information.
  - Added prominent call-to-action content, job-listing and nonprofit links.
  - Improved the contact form’s success state with a styled confirmation card.
  - Added a “Sending...” indicator during form submission.

- **Style**
  - Refreshed styling for form fields, validation messages, CAPTCHA, errors, and submit controls.
  - Updated the page hero and overall contact page presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->